### PR TITLE
docs: clarify demo mode ServiceEvent emission

### DIFF
--- a/PLAN_docs_audit.md
+++ b/PLAN_docs_audit.md
@@ -1,0 +1,14 @@
+# Plan: Internal docs audit (non-RFC)
+
+## Scope
+- Review non-RFC internal docs under `docs/architecture/` and `docs/standards/`.
+- Cross-check key claims against implementation where possible.
+- Record mismatches and update docs when needed.
+
+## Progress
+- [x] Scanned non-RFC docs and cross-checked selected claims against code.
+- [x] Corrected service-events note about demo mode emission behavior.
+- [x] Summarized audit findings for the user.
+
+## Sign-off
+- Completed.

--- a/docs/architecture/service-events.md
+++ b/docs/architecture/service-events.md
@@ -133,7 +133,7 @@ Event types are string constants emitted by services. The list below reflects cu
 
 **Notes**
 
-- Demo mode skips ServiceEvent emission in the Gateway.
+- Demo mode still emits ServiceEvents if the Decklog client is configured, using the demo tenant/user context.
 - Only **metadata** is stored for support events; message content is excluded.
 - API usage aggregates include **hashed** user/token identifiers for unique counts (no raw IDs stored).
 - Foghorn emits `artifact_lifecycle` service events via the Decklog client when sending clip/DVR/VOD lifecycle analytics.


### PR DESCRIPTION
### Motivation

- Correct the Service Events documentation to match the observed behavior in code where demo mode can still emit ServiceEvents when a Decklog client is configured, and record the lightweight audit plan used to validate docs.

### Description

- Update `docs/architecture/service-events.md` to change the note from "Demo mode skips ServiceEvent emission in the Gateway." to indicate demo mode still emits ServiceEvents when `Decklog` is configured and uses the demo tenant/user context.
- Add `PLAN_docs_audit.md` to record the scope and completion of the internal docs audit that produced the correction.

### Testing

- Ran `make lint`, which failed due to a `golangci-lint` config decoding error (`output.formats` expected a map, got a slice).
- Ran `pnpm lint`, which completed but emitted engine warnings and existing linter warnings (no blocking errors).
- Ran `pnpm format`, which completed successfully and formatted repository files where needed.
- The repository pre-commit hook executed `frontend-format` during the commit and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e3b211108330b8073621e1b826b8)