### PR TITLE
docs: align edge CLI examples, add Makefile `build-bin-forms`, and clarify Listmonk ports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-images build-bin-commodore build-bin-quartermaster build-bin-purser build-bin-decklog build-bin-foghorn build-bin-helmsman build-bin-periscope-ingest build-bin-periscope-query build-bin-signalman build-bin-bridge build-bin-deckhand \
+.PHONY: build build-images build-bin-commodore build-bin-quartermaster build-bin-purser build-bin-decklog build-bin-foghorn build-bin-helmsman build-bin-periscope-ingest build-bin-periscope-query build-bin-signalman build-bin-bridge build-bin-deckhand build-bin-forms \
 	build-image-commodore build-image-quartermaster build-image-purser build-image-decklog build-image-foghorn build-image-helmsman build-image-periscope-ingest build-image-periscope-query build-image-signalman build-image-bridge build-image-deckhand \
 	proto graphql graphql-frontend graphql-all clean version install-tools verify test coverage env tidy fmt \
 	lint lint-all lint-fix lint-report lint-analyze \
@@ -206,6 +206,9 @@ build-bin-privateer: proto
 
 build-bin-deckhand: proto
 	cd api_ticketing && go build $(LDFLAGS) -o ../bin/deckhand cmd/deckhand/main.go
+
+build-bin-forms: proto
+	cd api_forms && go build $(LDFLAGS) -o ../bin/forms cmd/forms/main.go
 
 # Clean build artifacts
 clean:

--- a/website_docs/src/content/docs/hybrid/connecting.mdx
+++ b/website_docs/src/content/docs/hybrid/connecting.mdx
@@ -60,7 +60,7 @@ After enrollment, your node appears in the dashboard under **Infrastructure → 
 Check that your node is talking to the network:
 
 ```bash
-frameworks edge status
+frameworks edge status --dir /opt/frameworks-edge
 ```
 
 This shows:

--- a/website_docs/src/content/docs/hybrid/node-cli.mdx
+++ b/website_docs/src/content/docs/hybrid/node-cli.mdx
@@ -11,7 +11,7 @@ Managing edge nodes shouldn't be a chore. The FrameWorks CLI provides a focused 
 ## Status
 
 ```bash
-frameworks edge status
+frameworks edge status --dir /opt/frameworks-edge
 ```
 
 Shows:
@@ -23,13 +23,13 @@ Shows:
 
 ```bash
 # All containers, follow mode
-frameworks edge logs --follow
+frameworks edge logs --follow --dir /opt/frameworks-edge
 
 # Specific container (positional argument)
-frameworks edge logs helmsman --tail 100
+frameworks edge logs helmsman --tail 100 --dir /opt/frameworks-edge
 
 # Multiple options
-frameworks edge logs --follow --tail 50
+frameworks edge logs --follow --tail 50 --dir /opt/frameworks-edge
 ```
 
 Service names: `mistserver`, `helmsman`, `caddy` (the proxy service)
@@ -39,7 +39,7 @@ Service names: `mistserver`, `helmsman`, `caddy` (the proxy service)
 Pull the latest images and restart:
 
 ```bash
-frameworks edge update
+frameworks edge update --dir /opt/frameworks-edge
 ```
 
 This:
@@ -61,14 +61,14 @@ frameworks version
 Check TLS status:
 
 ```bash
-frameworks edge cert
+frameworks edge cert --dir /opt/frameworks-edge
 ```
 
 Shows certificate expiration and issuer. Caddy handles renewal automatically, but if something goes wrong:
 
 ```bash
 # Reload Caddy to pick up new certificates
-frameworks edge cert --reload
+frameworks edge cert --reload --dir /opt/frameworks-edge
 ```
 
 ## Restarting Services
@@ -108,7 +108,7 @@ docker compose -f docker-compose.edge.yml up -d
 Full health check:
 
 ```bash
-frameworks edge doctor
+frameworks edge doctor --dir /opt/frameworks-edge
 ```
 
 Runs:

--- a/website_docs/src/content/docs/operators/architecture.mdx
+++ b/website_docs/src/content/docs/operators/architecture.mdx
@@ -46,29 +46,29 @@ The FrameWorks platform is composed of specialized services, each responsible fo
 
 ### Core Services
 
-| Service                  | Port                | Tier     | Purpose                                                             |
-| ------------------------ | ------------------- | -------- | ------------------------------------------------------------------- |
-| **Control Plane**        |                     |          |                                                                     |
-| Bridge                   | 18000               | Regional | GraphQL API Gateway (aggregates all services)                       |
-| Commodore                | 18001               | Central  | Business logic & orchestration API                                  |
-| Quartermaster            | 18002               | Central  | Tenant management API                                               |
-| Purser                   | 18003               | Central  | Billing API                                                         |
-| Navigator                | 18010, 18011 (gRPC) | Central  | DNS automation & ACME certificates (Future: Self-hosted Anycast) \* |
-| **Data Plane**           |                     |          |                                                                     |
-| Periscope Query          | 18004               | Central  | Analytics & reporting API                                           |
-| Periscope Ingest         | 18005               | Regional | Kafka event processing                                              |
-| Decklog                  | 18006               | Regional | gRPC event ingress → Kafka                                          |
-| Decklog (metrics)        | 18026               | Regional | Prometheus metrics                                                  |
-| Signalman                | 18009               | Regional | Real-time updates & WebSocket hub                                   |
-| **Media Plane**          |                     |          |                                                                     |
-| Foghorn                  | 18008               | Regional | Load balancer                                                       |
-| Foghorn (control)        | 18019               | Regional | gRPC control API                                                    |
-| Helmsman                 | 18007               | Edge     | MistServer sidecar                                                  |
-| **Support & Interfaces** |                     |          |                                                                     |
-| Deckhand                 | 18015               | Central  | Support messaging API (Chatwoot adapter)                            |
-| Web Console              | 18030               | Central  | Main application interface                                          |
-| Marketing Site           | 18031               | Central  | Public website                                                      |
-| Forms                    | 18032               | Central  | Contact form handling                                               |
+| Service                  | Port(s)                    | Tier     | Purpose                                                             |
+| ------------------------ | -------------------------- | -------- | ------------------------------------------------------------------- |
+| **Control Plane**        |                            |          |                                                                     |
+| Bridge                   | 18000                      | Regional | GraphQL API Gateway (aggregates all services)                       |
+| Commodore                | 18001 (HTTP), 19001 (gRPC) | Central  | Business logic & orchestration API                                  |
+| Quartermaster            | 18002 (HTTP), 19002 (gRPC) | Central  | Tenant management API                                               |
+| Purser                   | 18003 (HTTP), 19003 (gRPC) | Central  | Billing API                                                         |
+| Navigator                | 18010 (HTTP), 18011 (gRPC) | Central  | DNS automation & ACME certificates (Future: Self-hosted Anycast) \* |
+| **Data Plane**           |                            |          |                                                                     |
+| Periscope Query          | 18004 (HTTP), 19004 (gRPC) | Central  | Analytics & reporting API                                           |
+| Periscope Ingest         | 18005                      | Regional | Kafka event processing                                              |
+| Decklog                  | 18006 (gRPC)               | Regional | gRPC event ingress → Kafka                                          |
+| Decklog (metrics)        | 18026                      | Regional | Prometheus metrics                                                  |
+| Signalman                | 18009 (WS), 19005 (gRPC)   | Regional | Real-time updates & WebSocket hub                                   |
+| **Media Plane**          |                            |          |                                                                     |
+| Foghorn                  | 18008                      | Regional | Load balancer                                                       |
+| Foghorn (control)        | 18019 (gRPC)               | Regional | gRPC control API                                                    |
+| Helmsman                 | 18007 (gRPC)               | Edge     | MistServer sidecar                                                  |
+| **Support & Interfaces** |                            |          |                                                                     |
+| Deckhand                 | 18015 (HTTP), 19006 (gRPC) | Central  | Support messaging API (Chatwoot adapter)                            |
+| Web Console              | 18030                      | Central  | Main application interface                                          |
+| Marketing Site           | 18031                      | Central  | Public website                                                      |
+| Forms                    | 18032                      | Central  | Contact form handling                                               |
 
 ### Infrastructure Components
 
@@ -84,7 +84,7 @@ The FrameWorks platform is composed of specialized services, each responsible fo
 | Nginx                                        | Reverse proxy & routing             | Support        | 18090                                              | Central                                    |
 | VictoriaMetrics (or Prometheus)              | Metrics collection                  | Support        | Operator-defined                                   | Central                                    |
 | Grafana                                      | Metrics visualization               | Support        | Operator-defined                                   | Central                                    |
-| Listmonk                                     | Newsletter/mailing list manager     | Support        | 9000                                               | Central                                    |
+| Listmonk                                     | Newsletter/mailing list manager     | Support        | 9000 (service), 9001 (docker-compose host)         | Central                                    |
 
 _Navigator and Privateer are in testing. Production rollout is controlled and may not be enabled in every environment._
 

--- a/website_docs/src/content/docs/operators/deployment-manual.mdx
+++ b/website_docs/src/content/docs/operators/deployment-manual.mdx
@@ -254,23 +254,26 @@ kafka-topics.sh --bootstrap-server $BROKER --create \
 
 **Support Services (External):**
 
-| Service  | Port | Notes                     |
-| -------- | ---- | ------------------------- |
-| Listmonk | 9000 | Newsletter backend (HTTP) |
-| Chatwoot | 3000 | Support dashboard + API   |
-| Redis    | 6379 | Chatwoot dependency       |
+| Service  | Port                                            | Notes                     |
+| -------- | ----------------------------------------------- | ------------------------- |
+| Listmonk | 9000 (service), 9001 (repo docker-compose host) | Newsletter backend (HTTP) |
+| Chatwoot | 3000                                            | Support dashboard + API   |
+| Redis    | 6379                                            | Chatwoot dependency       |
 
 ### Build Binaries
 
 ```bash
 cd /path/to/monorepo
 
-go build -o /opt/frameworks/bin/quartermaster ./api_tenants/cmd/quartermaster/
-go build -o /opt/frameworks/bin/commodore ./api_control/cmd/commodore/
-go build -o /opt/frameworks/bin/purser ./api_billing/cmd/purser/
-go build -o /opt/frameworks/bin/periscope-query ./api_analytics_query/cmd/periscope/
-go build -o /opt/frameworks/bin/deckhand ./api_ticketing/cmd/deckhand/
-go build -o /opt/frameworks/bin/forms ./api_forms/cmd/forms/
+make build-bin-quartermaster
+make build-bin-commodore
+make build-bin-purser
+make build-bin-periscope-query
+make build-bin-deckhand
+make build-bin-forms
+
+install -d /opt/frameworks/bin
+cp bin/quartermaster bin/commodore bin/purser bin/periscope-query bin/deckhand bin/forms /opt/frameworks/bin/
 ```
 
 ### Environment Configuration
@@ -437,7 +440,7 @@ FROM_EMAIL=info@your-domain.com
 TO_EMAIL=contact@your-domain.com
 
 # Listmonk
-LISTMONK_URL=http://127.0.0.1:9000
+LISTMONK_URL=http://<listmonk-host>:9000 # Use :9001 if you rely on the repo docker-compose port mapping
 LISTMONK_USERNAME=admin
 LISTMONK_PASSWORD=<listmonk-password>
 DEFAULT_MAILING_LIST_ID=1
@@ -496,12 +499,16 @@ Ensure it can reach the Postgres/Yugabyte instance and the `listmonk` database/u
 # Docker example
 docker run -d --name listmonk \
   -p 9000:9000 \
-  -e LISTMONK_DB_HOST=<db-host> \
-  -e LISTMONK_DB_PORT=<db-port> \
-  -e LISTMONK_DB_USER=listmonk \
-  -e LISTMONK_DB_PASSWORD=<listmonk-db-password> \
-  -e LISTMONK_DB_DATABASE=listmonk \
-  listmonk/listmonk:latest
+  -e LISTMONK_app__address="0.0.0.0:9000" \
+  -e LISTMONK_app__admin_username=admin \
+  -e LISTMONK_app__admin_password=<listmonk-admin-password> \
+  -e LISTMONK_db__host=<db-host> \
+  -e LISTMONK_db__port=<db-port> \
+  -e LISTMONK_db__user=listmonk \
+  -e LISTMONK_db__password=<listmonk-db-password> \
+  -e LISTMONK_db__database=listmonk \
+  -e LISTMONK_db__ssl_mode=disable \
+  listmonk/listmonk:v4.0.1
 ```
 
 ---

--- a/website_docs/src/content/docs/streamers/mcp.mdx
+++ b/website_docs/src/content/docs/streamers/mcp.mdx
@@ -83,32 +83,32 @@ X-PAYMENT: <base64-encoded payload>
 (`PAYMENT-SIGNATURE` is also accepted.)
 
 Get API tokens from **Developer → API** in the dashboard.
-Some resources and tools are public (e.g., `account://status`, `billing://pricing`, `resolve_playback_endpoint`, `get_payment_options`).
+Some resources and tools are public (e.g., `account://status`, `billing://pricing`, `resolve_playback_endpoint`, `get_payment_options`, `submit_payment`).
 
 ## Resources
 
 Read-only data sources.
 
-| URI                            | Description                                       |
-| ------------------------------ | ------------------------------------------------- |
-| `account://status`             | Account status, blockers, and capabilities        |
-| `billing://balance`            | Prepaid balance, drain rate, estimated hours left |
-| `billing://pricing`            | Current pricing rates                             |
-| `billing://transactions`       | Recent balance transactions                       |
-| `streams://list`               | List all streams                                  |
-| `streams://{id}`               | Stream details (relay ID or stream_id)            |
-| `streams://{id}/health`        | Stream health metrics                             |
-| `vod://list`                   | List all VOD assets                               |
-| `vod://{artifact_hash}`        | VOD asset details (relay ID or artifact hash)     |
-| `analytics://usage`            | Current billing period usage                      |
-| `analytics://viewers`          | Viewer metrics (last 24h)                         |
-| `analytics://geographic`       | Geographic viewer distribution                    |
-| `nodes://list`                 | Infrastructure nodes                              |
-| `nodes://{id}`                 | Node details                                      |
-| `support://conversations`      | Support conversation list                         |
-| `support://conversations/{id}` | Support conversation details                      |
-| `knowledge://sources`          | Curated documentation sources for video streaming |
-| `schema://catalog`             | Curated GraphQL catalog (schema + templates)      |
+| URI                                         | Description                                       |
+| ------------------------------------------- | ------------------------------------------------- |
+| `account://status`                          | Account status, blockers, and capabilities        |
+| `billing://balance`                         | Prepaid balance, drain rate, estimated hours left |
+| `billing://pricing`                         | Current pricing rates                             |
+| `billing://transactions`                    | Recent balance transactions                       |
+| `streams://list`                            | List all streams                                  |
+| `streams://{id}`                            | Stream details (relay ID or stream_id)            |
+| `streams://{id}/health`                     | Stream health metrics                             |
+| `vod://list`                                | List all VOD assets                               |
+| `vod://{artifact_hash}`                     | VOD asset details (relay ID or artifact hash)     |
+| `analytics://usage`                         | Current billing period usage                      |
+| `analytics://viewers`                       | Viewer metrics (last 24h)                         |
+| `analytics://geographic`                    | Geographic viewer distribution                    |
+| `nodes://list`                              | Infrastructure nodes                              |
+| `nodes://{id}`                              | Node details                                      |
+| `support://conversations`                   | Support conversation list                         |
+| `support://conversations/{conversation_id}` | Support conversation details                      |
+| `knowledge://sources`                       | Curated documentation sources for video streaming |
+| `schema://catalog`                          | Curated GraphQL catalog (schema + templates)      |
 
 ### account://status
 


### PR DESCRIPTION
### Motivation
- Ensure operator docs are accurate and follow repository tooling by preferring Makefile targets over ad-hoc `go build` commands. 
- Make edge node CLI examples deterministic by using explicit `--dir` paths so examples match how the CLI resolves stack files. 
- Remove confusion around Listmonk port mappings between the service and repo docker-compose examples.

### Description
- Added a Makefile target `build-bin-forms` that builds the `forms` binary (`api_forms`) so documentation can reference `make` targets consistently. 
- Updated edge/Hybrid docs to use the explicit `--dir /opt/frameworks-edge` flag for `frameworks edge` commands in `connecting.mdx` and `node-cli.mdx`. 
- Updated the deployment manual to prefer `make build-bin-<service>` (including `make build-bin-forms`), add `install`/`cp` steps to copy built binaries to `/opt/frameworks/bin`, and replace several inline `go build` snippets. 
- Clarified Listmonk notes across docs: documented both the service port and the repo/docker-compose host port (`9000` service, `9001` host mapping), pinned the example docker image and expanded the `-e` env var mapping to match the repo convention. 
- Adjusted the architecture service table to show HTTP vs gRPC ports for core services and applied small content fixes (streamers MCP resources list update).

### Testing
- Ran `pnpm lint`, which completed successfully but reported existing `@typescript-eslint/no-explicit-any` warnings in `npm_player`/`npm_studio` workspaces. 
- Ran `pnpm format` (Prettier) which completed successfully and formatted documentation files. 
- Pre-commit frontend format hook ran as part of the commit (frontend-format) and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980e8a02b608330b8392eaee9065992)