### PR TITLE
Harden tenant scoping for analytics

### DIFF
--- a/api_gateway/internal/mcp/tools/qoe.go
+++ b/api_gateway/internal/mcp/tools/qoe.go
@@ -310,7 +310,7 @@ func handleDiagnoseBufferHealth(ctx context.Context, args DiagnoseBufferHealthIn
 		return toolError(fmt.Sprintf("Failed to fetch buffer health data: %v", err))
 	}
 
-	metricsResp, err := serviceClients.Periscope.GetStreamHealthMetrics(ctx, &streamID, timeRange, &periscope.CursorPaginationOpts{First: 200})
+	metricsResp, err := serviceClients.Periscope.GetStreamHealthMetrics(ctx, tenantID, &streamID, timeRange, &periscope.CursorPaginationOpts{First: 200})
 	if err != nil {
 		logger.WithError(err).Warn("Failed to get stream health samples")
 	}
@@ -485,7 +485,7 @@ func handleDiagnosePacketLoss(ctx context.Context, args DiagnosePacketLossInput,
 
 	protocol := ""
 	protocolType := protocolTypeUnknown
-	eventResp, err := serviceClients.Periscope.GetStreamEvents(ctx, streamID, timeRange, &periscope.CursorPaginationOpts{First: 20})
+	eventResp, err := serviceClients.Periscope.GetStreamEvents(ctx, tenantID, streamID, timeRange, &periscope.CursorPaginationOpts{First: 20})
 	if err == nil {
 		for _, evt := range eventResp.Events {
 			if evt.Protocol != nil && *evt.Protocol != "" {
@@ -558,7 +558,7 @@ func handleDiagnoseRouting(ctx context.Context, args DiagnoseRoutingInput, servi
 	}
 
 	timeRangeLabel, timeRange := normalizeTimeRange(args.TimeRange)
-	resp, err := serviceClients.Periscope.GetRoutingEvents(ctx, &streamID, timeRange, nil, []string{tenantID}, nil, nil)
+	resp, err := serviceClients.Periscope.GetRoutingEvents(ctx, tenantID, &streamID, timeRange, nil, []string{tenantID}, nil, nil)
 	if err != nil {
 		logger.WithError(err).Warn("Failed to get routing events")
 		return toolError(fmt.Sprintf("Failed to fetch routing data: %v", err))

--- a/api_gateway/internal/resolvers/tenant.go
+++ b/api_gateway/internal/resolvers/tenant.go
@@ -1,0 +1,13 @@
+package resolvers
+
+import "context"
+
+func tenantIDFromContext(ctx context.Context) string {
+	if ctx == nil {
+		return ""
+	}
+	if tenantID, ok := ctx.Value("tenant_id").(string); ok {
+		return tenantID
+	}
+	return ""
+}

--- a/pkg/clients/periscope/grpc_client.go
+++ b/pkg/clients/periscope/grpc_client.go
@@ -190,8 +190,9 @@ func (c *GRPCClient) GetLiveUsageSummary(ctx context.Context, tenantID string, t
 }
 
 // GetStreamEvents returns events for a specific stream with cursor pagination
-func (c *GRPCClient) GetStreamEvents(ctx context.Context, streamID string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetStreamEventsResponse, error) {
+func (c *GRPCClient) GetStreamEvents(ctx context.Context, tenantID string, streamID string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetStreamEventsResponse, error) {
 	return c.stream.GetStreamEvents(ctx, &pb.GetStreamEventsRequest{
+		TenantId:   tenantID,
 		StreamId:   streamID,
 		TimeRange:  buildTimeRange(timeRange),
 		Pagination: buildCursorPagination(opts),
@@ -199,8 +200,9 @@ func (c *GRPCClient) GetStreamEvents(ctx context.Context, streamID string, timeR
 }
 
 // GetBufferEvents returns buffer events for a specific stream
-func (c *GRPCClient) GetBufferEvents(ctx context.Context, streamID string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetBufferEventsResponse, error) {
+func (c *GRPCClient) GetBufferEvents(ctx context.Context, tenantID string, streamID string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetBufferEventsResponse, error) {
 	return c.stream.GetBufferEvents(ctx, &pb.GetBufferEventsRequest{
+		TenantId:   tenantID,
 		StreamId:   streamID,
 		TimeRange:  buildTimeRange(timeRange),
 		Pagination: buildCursorPagination(opts),
@@ -208,8 +210,9 @@ func (c *GRPCClient) GetBufferEvents(ctx context.Context, streamID string, timeR
 }
 
 // GetStreamHealthMetrics returns stream health metrics
-func (c *GRPCClient) GetStreamHealthMetrics(ctx context.Context, streamID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetStreamHealthMetricsResponse, error) {
+func (c *GRPCClient) GetStreamHealthMetrics(ctx context.Context, tenantID string, streamID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetStreamHealthMetricsResponse, error) {
 	req := &pb.GetStreamHealthMetricsRequest{
+		TenantId:   tenantID,
 		TimeRange:  buildTimeRange(timeRange),
 		Pagination: buildCursorPagination(opts),
 	}
@@ -287,8 +290,9 @@ func (c *GRPCClient) GetGeographicDistribution(ctx context.Context, tenantID str
 // ============================================================================
 
 // GetTrackListEvents returns track list updates for a specific stream
-func (c *GRPCClient) GetTrackListEvents(ctx context.Context, streamID string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetTrackListEventsResponse, error) {
+func (c *GRPCClient) GetTrackListEvents(ctx context.Context, tenantID string, streamID string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetTrackListEventsResponse, error) {
 	return c.track.GetTrackListEvents(ctx, &pb.GetTrackListEventsRequest{
+		TenantId:   tenantID,
 		StreamId:   streamID,
 		TimeRange:  buildTimeRange(timeRange),
 		Pagination: buildCursorPagination(opts),
@@ -300,8 +304,9 @@ func (c *GRPCClient) GetTrackListEvents(ctx context.Context, streamID string, ti
 // ============================================================================
 
 // GetConnectionEvents returns connection events
-func (c *GRPCClient) GetConnectionEvents(ctx context.Context, streamID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetConnectionEventsResponse, error) {
+func (c *GRPCClient) GetConnectionEvents(ctx context.Context, tenantID string, streamID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetConnectionEventsResponse, error) {
 	req := &pb.GetConnectionEventsRequest{
+		TenantId:   tenantID,
 		TimeRange:  buildTimeRange(timeRange),
 		Pagination: buildCursorPagination(opts),
 	}
@@ -316,8 +321,9 @@ func (c *GRPCClient) GetConnectionEvents(ctx context.Context, streamID *string, 
 // ============================================================================
 
 // GetNodeMetrics returns node performance metrics
-func (c *GRPCClient) GetNodeMetrics(ctx context.Context, nodeID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetNodeMetricsResponse, error) {
+func (c *GRPCClient) GetNodeMetrics(ctx context.Context, tenantID string, nodeID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetNodeMetricsResponse, error) {
 	req := &pb.GetNodeMetricsRequest{
+		TenantId:   tenantID,
 		TimeRange:  buildTimeRange(timeRange),
 		Pagination: buildCursorPagination(opts),
 	}
@@ -328,8 +334,9 @@ func (c *GRPCClient) GetNodeMetrics(ctx context.Context, nodeID *string, timeRan
 }
 
 // GetNodeMetrics1H returns hourly aggregated node metrics
-func (c *GRPCClient) GetNodeMetrics1H(ctx context.Context, nodeID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetNodeMetrics1HResponse, error) {
+func (c *GRPCClient) GetNodeMetrics1H(ctx context.Context, tenantID string, nodeID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetNodeMetrics1HResponse, error) {
 	req := &pb.GetNodeMetrics1HRequest{
+		TenantId:   tenantID,
 		TimeRange:  buildTimeRange(timeRange),
 		Pagination: buildCursorPagination(opts),
 	}
@@ -340,8 +347,9 @@ func (c *GRPCClient) GetNodeMetrics1H(ctx context.Context, nodeID *string, timeR
 }
 
 // GetNodeMetricsAggregated returns per-node aggregates for the requested time range.
-func (c *GRPCClient) GetNodeMetricsAggregated(ctx context.Context, nodeID *string, timeRange *TimeRangeOpts) (*pb.GetNodeMetricsAggregatedResponse, error) {
+func (c *GRPCClient) GetNodeMetricsAggregated(ctx context.Context, tenantID string, nodeID *string, timeRange *TimeRangeOpts) (*pb.GetNodeMetricsAggregatedResponse, error) {
 	req := &pb.GetNodeMetricsAggregatedRequest{
+		TenantId:  tenantID,
 		TimeRange: buildTimeRange(timeRange),
 	}
 	if nodeID != nil {
@@ -352,8 +360,9 @@ func (c *GRPCClient) GetNodeMetricsAggregated(ctx context.Context, nodeID *strin
 
 // GetLiveNodes returns current state of nodes from live_nodes (ReplacingMergeTree)
 // Supports multi-tenant access for subscribed clusters via relatedTenantIDs
-func (c *GRPCClient) GetLiveNodes(ctx context.Context, nodeID *string, relatedTenantIDs []string) (*pb.GetLiveNodesResponse, error) {
+func (c *GRPCClient) GetLiveNodes(ctx context.Context, tenantID string, nodeID *string, relatedTenantIDs []string) (*pb.GetLiveNodesResponse, error) {
 	req := &pb.GetLiveNodesRequest{
+		TenantId:         tenantID,
 		RelatedTenantIds: relatedTenantIDs,
 	}
 	if nodeID != nil {
@@ -367,8 +376,9 @@ func (c *GRPCClient) GetLiveNodes(ctx context.Context, nodeID *string, relatedTe
 // ============================================================================
 
 // GetRoutingEvents returns routing decision events
-func (c *GRPCClient) GetRoutingEvents(ctx context.Context, streamID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts, relatedTenantIDs []string, subjectTenantID, clusterID *string) (*pb.GetRoutingEventsResponse, error) {
+func (c *GRPCClient) GetRoutingEvents(ctx context.Context, tenantID string, streamID *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts, relatedTenantIDs []string, subjectTenantID, clusterID *string) (*pb.GetRoutingEventsResponse, error) {
 	req := &pb.GetRoutingEventsRequest{
+		TenantId:         tenantID,
 		TimeRange:        buildTimeRange(timeRange),
 		Pagination:       buildCursorPagination(opts),
 		RelatedTenantIds: relatedTenantIDs,
@@ -403,8 +413,9 @@ func (c *GRPCClient) GetPlatformOverview(ctx context.Context, tenantID string, t
 // ============================================================================
 
 // GetClipEvents returns artifact lifecycle events (clip/dvr/vod)
-func (c *GRPCClient) GetClipEvents(ctx context.Context, streamID *string, stage *string, contentType *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetClipEventsResponse, error) {
+func (c *GRPCClient) GetClipEvents(ctx context.Context, tenantID string, streamID *string, stage *string, contentType *string, timeRange *TimeRangeOpts, opts *CursorPaginationOpts) (*pb.GetClipEventsResponse, error) {
 	req := &pb.GetClipEventsRequest{
+		TenantId:   tenantID,
 		TimeRange:  buildTimeRange(timeRange),
 		Pagination: buildCursorPagination(opts),
 	}


### PR DESCRIPTION
### Motivation

- Prevent cross-tenant data leaks by ensuring all Periscope queries and cache keys are scoped to a tenant.
- Ensure gRPC requests explicitly set the `TenantId` field instead of relying solely on metadata headers.
- Add runtime guards so analytics resolvers fail early when tenant context is missing.

### Description

- Added a small helper `tenantIDFromContext` in `api_gateway/internal/resolvers/tenant.go` to centralize tenant extraction from `context.Context`.
- Updated Periscope client method signatures in `pkg/clients/periscope/grpc_client.go` to accept `tenantID` and populate `TenantId` in all request messages (stream, buffer, health, node, routing, clip, live nodes, etc.).
- Changed analytics resolvers and helpers under `api_gateway/internal/resolvers/analytics.go` and `api_gateway/internal/resolvers/analytics_connections.go` to require tenant context, extract tenant ID via the helper, prepend tenant ID to cache key parts, and pass `tenantID` into Periscope client calls.
- Updated MCP QoE tooling (`api_gateway/internal/mcp/tools/qoe.go`) and other call sites to pass the extracted `tenantID` to the updated Periscope client methods.

### Testing

- Ran formatting and quick checks with `gofmt` on modified files and ensured code is gofmt-clean.
- Executed `make lint` which failed due to a linter configuration error unrelated to the code changes: golangci-lint reported "can't unmarshal config by viper: 'output.formats' expected a map, got 'slice'"; no unit test failures from the change itself were observed because lint did not complete.
- Verified code references and call sites with repository searches (`rg`) to ensure client signature updates were propagated to obvious callers; no unresolved references remain in the modified areas.

If desired, next steps are running the full test suite (`make test`) and resolving the CI linter config issue before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980ec27a634833088b94f247035a1b5)