### PR TITLE
Harden billing usage ingestion and Periscope DLQ/duplicate-event metrics

### DIFF
--- a/api_billing/internal/handlers/jobs.go
+++ b/api_billing/internal/handlers/jobs.go
@@ -311,8 +311,12 @@ func (jm *JobManager) Stop() {
 func (jm *JobManager) handleUsageReport(ctx context.Context, msg kafka.Message) error {
 	var summary models.UsageSummary
 	if err := json.Unmarshal(msg.Value, &summary); err != nil {
-		jm.logger.WithError(err).Error("Failed to unmarshal usage summary from Kafka")
-		return nil // Skip bad message
+		jm.logger.WithError(err).WithFields(logging.Fields{
+			"topic":     msg.Topic,
+			"partition": msg.Partition,
+			"offset":    msg.Offset,
+		}).Error("Failed to unmarshal usage summary from Kafka")
+		return fmt.Errorf("unmarshal usage summary: %w", err)
 	}
 
 	if err := jm.processUsageSummary(summary, "kafka"); err != nil {
@@ -1366,11 +1370,7 @@ func (jm *JobManager) processUsageSummary(summary models.UsageSummary, source st
 			INSERT INTO purser.usage_records (tenant_id, cluster_id, usage_type, usage_value, usage_details, period_start, period_end, granularity, created_at)
 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW())
 			ON CONFLICT (tenant_id, cluster_id, usage_type, period_start, period_end) DO UPDATE SET
-				usage_value = CASE
-					WHEN EXCLUDED.usage_type IN ('average_storage_gb', 'peak_bandwidth_mbps', 'max_viewers', 'total_streams', 'unique_users', 'unique_users_period')
-						THEN GREATEST(purser.usage_records.usage_value, EXCLUDED.usage_value)
-					ELSE purser.usage_records.usage_value + EXCLUDED.usage_value
-				END,
+				usage_value = EXCLUDED.usage_value,
 				usage_details = EXCLUDED.usage_details,
 				granularity = EXCLUDED.granularity,
 				updated_at = NOW()


### PR DESCRIPTION
### Motivation
- Prevent silent data loss and duplicate billing by surfacing bad Kafka payloads and making upserts idempotent for usage summaries.
- Provide observability for messages routed to the DLQ so alerts can be configured when the pipeline is degrading.
- Reduce double-inserts into ClickHouse rollups by skipping duplicate viewer connection events at the application layer.

### Description
- Treat malformed usage summaries as errors in `handleUsageReport` by returning an error and logging topic/partition/offset instead of silently returning `nil` (`api_billing/internal/handlers/jobs.go`).
- Change Purser usage upsert semantics to replace the period's `usage_value` with `EXCLUDED.usage_value` (last-writer-wins) to avoid additive double-charging (`api_billing/internal/handlers/jobs.go`).
- Add DLQ and duplicate-event Prometheus counters to Periscope metrics and increment the DLQ counter when a message is published to the DLQ (`api_analytics_ingest/cmd/periscope/main.go` and `api_analytics_ingest/internal/handlers/handlers.go`).
- Add an application-level de-duplication check before inserting `viewer_connection_events` by querying `viewer_connection_events` for `event_id` and skipping the insert if present, and incrementing the duplicate-events metric when skipped (`api_analytics_ingest/internal/handlers/handlers.go`).

### Testing
- Ran pre-commit hooks (`lefthook`) which executed `go-fmt` successfully.
- `go-lint` executed as part of the pre-commit hooks but failed due to a config decoding error (`output.formats` expected map, got slice), so lint issues unrelated to these changes were not fully validated.
- Basic manual verification steps described: sending the same usage summary twice should now replace instead of double-add, malformed usage payloads now return errors to trigger DLQ handling, and duplicate `event_id` insert attempts are skipped and counted by the new metric.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980eb90eb9c83308fcc67579b11dd5a)