### PR TITLE
Improve ingest error propagation and session ordering

### DIFF
--- a/api_analytics_ingest/internal/handlers/handlers.go
+++ b/api_analytics_ingest/internal/handlers/handlers.go
@@ -466,14 +466,13 @@ func (h *AnalyticsHandler) processStreamLifecycle(ctx context.Context, event kaf
 			has_issues, issues_description, track_count,
 			track_metadata,
 			audio_channels, audio_sample_rate, audio_codec, audio_bitrate
-		)`)
+	)`)
 	if err != nil {
 		h.logger.Errorf("Failed to prepare stream_health_metrics batch: %v", err)
 		if h.metrics != nil {
 			h.metrics.ClickHouseInserts.WithLabelValues("stream_health_metrics", "error").Inc()
 		}
-		// Don't fail the whole event if health insert fails - live_streams and stream_events are more important
-		return nil
+		return err
 	}
 
 	// Calculate buffer_health ratio (0.0-1.0): buffer_ms / max_keepaway_ms.
@@ -529,7 +528,7 @@ func (h *AnalyticsHandler) processStreamLifecycle(ctx context.Context, event kaf
 		if h.metrics != nil {
 			h.metrics.ClickHouseInserts.WithLabelValues("stream_health_metrics", "error").Inc()
 		}
-		return nil
+		return err
 	}
 
 	if err := healthBatch.Send(); err != nil {
@@ -537,7 +536,7 @@ func (h *AnalyticsHandler) processStreamLifecycle(ctx context.Context, event kaf
 		if h.metrics != nil {
 			h.metrics.ClickHouseInserts.WithLabelValues("stream_health_metrics", "error").Inc()
 		}
-		return nil
+		return err
 	}
 
 	if h.metrics != nil {

--- a/pkg/database/sql/clickhouse/periscope.sql
+++ b/pkg/database/sql/clickhouse/periscope.sql
@@ -367,7 +367,7 @@ CREATE TABLE IF NOT EXISTS viewer_sessions_current (
     internal_name LowCardinality(String),
     session_id String,
 
-    connected_at SimpleAggregateFunction(max, DateTime),
+    connected_at SimpleAggregateFunction(min, Nullable(DateTime)),
     disconnected_at SimpleAggregateFunction(max, Nullable(DateTime)),
 
     node_id SimpleAggregateFunction(any, LowCardinality(String)),
@@ -411,7 +411,7 @@ SELECT
     stream_id,
     internal_name,
     session_id,
-    toDateTime(0) AS connected_at,
+    CAST(NULL AS Nullable(DateTime)) AS connected_at,
     timestamp AS disconnected_at,
     node_id,
     connector,


### PR DESCRIPTION
### Motivation
- Ensure ClickHouse write failures in the ingest path are not silently swallowed so upstream consumers / DLQ logic can observe and act on failures. 
- Handle out-of-order viewer connect/disconnect events more robustly in the ClickHouse aggregating view to avoid spurious zero timestamps and enable correct session ordering.

### Description
- In `api_analytics_ingest/internal/handlers/handlers.go` the stream health insert error handling now returns the underlying error instead of returning `nil`, and metrics are still recorded on prepare/append/send failures so failures surface to the caller. 
- In `pkg/database/sql/clickhouse/periscope.sql` the `viewer_sessions_current.connected_at` aggregate was changed from `SimpleAggregateFunction(max, DateTime)` to `SimpleAggregateFunction(min, Nullable(DateTime))` to allow nullable/min semantics for ordering. 
- The `viewer_sessions_disconnect_mv` materialized view now emits `CAST(NULL AS Nullable(DateTime)) AS connected_at` instead of `toDateTime(0)` so disconnect-only rows do not produce a fake zero timestamp.

### Testing
- Ran `make lint`, which failed due to a repository-wide golangci-lint config error: `output.formats expected a map, got slice`, so lint could not complete successfully. 
- Pre-commit/go-lint hooks produced the same `output.formats` decoding error during the commit attempt, but the changes were staged and committed locally despite the lint tool configuration issue.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698115f913948330bf3c1f7ba05e1c92)