### PR TITLE
Fix periscope ingest lifecycle handling

### DIFF
--- a/api_analytics_ingest/README.md
+++ b/api_analytics_ingest/README.md
@@ -23,7 +23,7 @@ Consumes analytics events from Kafka and writes time‑series data exclusively t
 - `node_lifecycle_update` → `node_state_current` + `node_metrics_samples`
 - `client_lifecycle_update` → `client_qoe_samples`
 - `load_balancing` → `routing_decisions`
-- `clip_lifecycle`, `dvr_lifecycle` → `artifact_state_current` + `artifact_events`
+- `clip_lifecycle`, `dvr_lifecycle`, `vod_lifecycle` → `artifact_state_current` + `artifact_events`
 - `storage_snapshot` → `storage_snapshots`
 - `process_billing` → `processing_events`
 

--- a/api_analytics_ingest/internal/handlers/handlers.go
+++ b/api_analytics_ingest/internal/handlers/handlers.go
@@ -675,7 +675,7 @@ func (h *AnalyticsHandler) processViewerConnection(ctx context.Context, event ka
 	}
 
 	if err := batch.Append(
-		event.EventID,
+		parseUUID(event.EventID),
 		event.Timestamp,
 		event.TenantID,
 		parseUUID(mt.GetStreamId()),
@@ -2096,8 +2096,9 @@ func (h *AnalyticsHandler) processDVRLifecycle(ctx context.Context, event kafka.
 	}
 	dvrData := tp.DvrLifecycleData
 
-	var tenantID, internalName string
-	if dvrData.TenantId != nil {
+	tenantID := event.TenantID
+	var internalName string
+	if dvrData.TenantId != nil && *dvrData.TenantId != "" {
 		tenantID = *dvrData.TenantId
 	}
 	if dvrData.InternalName != nil {
@@ -2240,17 +2241,14 @@ func (h *AnalyticsHandler) processVodLifecycle(ctx context.Context, event kafka.
 	if err := h.parseProtobufData(event, &mt); err != nil {
 		return fmt.Errorf("failed to parse MistTrigger: %w", err)
 	}
-	if err := h.requireStreamID(ctx, event, mt.GetStreamId()); err != nil {
-		return err
-	}
 	tp, ok := mt.GetTriggerPayload().(*pb.MistTrigger_VodLifecycleData)
 	if !ok || tp == nil {
 		return fmt.Errorf("unexpected payload for vod_lifecycle")
 	}
 	vodData := tp.VodLifecycleData
 
-	var tenantID string
-	if vodData.TenantId != nil {
+	tenantID := event.TenantID
+	if vodData.TenantId != nil && *vodData.TenantId != "" {
 		tenantID = *vodData.TenantId
 	}
 


### PR DESCRIPTION
### Motivation
- Prevent valid VOD lifecycle events from being dropped due to an incorrect `requireStreamID` check.
- Ensure DVR and VOD lifecycle inserts use a safe `tenant_id` fallback from the Kafka event when payload fields are empty.
- Avoid inserting raw string event IDs into a UUID column by explicitly parsing event IDs.
- Document that `vod_lifecycle` maps to the artifact tables.

### Description
- Removed the `requireStreamID` check from `processVodLifecycle` so VOD uploads without a stream ID are accepted (`api_analytics_ingest/internal/handlers/handlers.go`).
- Use `event.TenantID` as the default and only override when payload `TenantId` is present and non-empty for both DVR and VOD handlers (`processDVRLifecycle` and `processVodLifecycle` in `api_analytics_ingest/internal/handlers/handlers.go`).
- Parse `event.EventID` into a UUID before appending to the ClickHouse batch in the viewer connection path by replacing `event.EventID` with `parseUUID(event.EventID)` (`api_analytics_ingest/internal/handlers/handlers.go`).
- Add `vod_lifecycle` to the event→table mapping in `api_analytics_ingest/README.md`.

### Testing
- Ran `make lint`, which failed due to a golangci-lint configuration error: `output.formats` expected a map (lint did not complete successfully).
- Ran `make test`, which failed during proto generation because `protoc` could not find `google/protobuf/timestamp.proto` (tests did not complete successfully).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981bf631c0c83308d49561375853555)