### PR TITLE
Improve playback diagnostics for blacklisted protocols

### DIFF
--- a/npm_player/packages/core/src/core/PlayerInterface.ts
+++ b/npm_player/packages/core/src/core/PlayerInterface.ts
@@ -137,6 +137,7 @@ export enum ErrorCode {
 
   // Tier 4: Fatal
   ALL_PROTOCOLS_EXHAUSTED = "ALL_PROTOCOLS_EXHAUSTED",
+  ALL_PROTOCOLS_BLACKLISTED = "ALL_PROTOCOLS_BLACKLISTED",
   STREAM_OFFLINE = "STREAM_OFFLINE",
   AUTH_REQUIRED = "AUTH_REQUIRED",
   GEO_BLOCKED = "GEO_BLOCKED",
@@ -164,6 +165,13 @@ export interface ClassifiedError {
   originalError?: Error | string;
   /** Timestamp when error occurred */
   timestamp: number;
+  /** Diagnostic details for operators/debugging */
+  details?: {
+    incompatibilityReasons?: string[];
+    blacklistedProtocols?: string[];
+    originalCode?: ErrorCode;
+    originalMessage?: string;
+  };
 }
 
 /**

--- a/npm_player/packages/svelte/src/stores/playerController.ts
+++ b/npm_player/packages/svelte/src/stores/playerController.ts
@@ -12,6 +12,7 @@ import {
   type PlaybackQuality,
   type ContentEndpoints,
   type ContentMetadata,
+  type ClassifiedError,
 } from "@livepeer-frameworks/player-core";
 
 // ============================================================================
@@ -50,6 +51,8 @@ export interface PlayerControllerState {
   volume: number;
   /** Error text */
   error: string | null;
+  /** Error details for debugging */
+  errorDetails: ClassifiedError["details"] | null;
   /** Is passive error */
   isPassiveError: boolean;
   /** Has playback ever started */
@@ -162,6 +165,7 @@ const initialState: PlayerControllerState = {
   isMuted: true,
   volume: 1,
   error: null,
+  errorDetails: null,
   isPassiveError: false,
   hasPlaybackStarted: false,
   isHoldingSpeed: false,
@@ -419,6 +423,7 @@ export function createPlayerControllerStore(
         store.update((prev) => ({
           ...prev,
           error: data.message,
+          errorDetails: data.details ?? null,
           isPassiveError: false,
         }));
       })
@@ -506,7 +511,12 @@ export function createPlayerControllerStore(
 
   function clearError(): void {
     controller?.clearError();
-    store.update((prev) => ({ ...prev, error: null, isPassiveError: false }));
+    store.update((prev) => ({
+      ...prev,
+      error: null,
+      errorDetails: null,
+      isPassiveError: false,
+    }));
   }
 
   function dismissToast(): void {


### PR DESCRIPTION
### Motivation

- The selection flow produced a generic, non-actionable fatal message when all stream sources were rejected (e.g. because protocols were blacklisted), making operator debugging difficult. 
- Escalation logic previously overwrote specific error context when alternatives were exhausted, losing the original failure reason. 
- UI layers lacked access to diagnostic information (blacklisted protocols, incompatibility reasons) needed for clearer error modals and operator tooling.

### Description

- Add `ALL_PROTOCOLS_BLACKLISTED` to `ErrorCode` and a `details` field to `ClassifiedError` for optional diagnostic payloads in `npm_player/packages/core/src/core/PlayerInterface.ts`.
- Extend `ErrorClassifier` with a `RETRY_CONFIG`/`CODE_TO_SEVERITY`/`CODE_TO_MESSAGE` entry for the new code, preserve original error context during escalation, and add `classifyWithDetails()` to accept & emit pre-computed diagnostics (`npm_player/packages/core/src/core/ErrorClassifier.ts`).
- Add `diagnoseNoPlayersAvailable()` to `PlayerManager` to detect all-blacklisted-source cases and compute incompatibility summaries, then use `classifyWithDetails()` when selection fails (`npm_player/packages/core/src/core/PlayerManager.ts`).
- Surface diagnostic details to framework consumers by exposing `errorDetails` in React and Svelte controller states and adding `details` to the `onPlaybackFailed` callback payload (`npm_player/packages/react/src/hooks/usePlayerController.ts`, `npm_player/packages/svelte/src/stores/playerController.ts`).

### Testing

- Ran workspace lint via `pnpm lint`; lint completed but reported existing TypeScript/ESLint warnings and a Node engine warning (no new errors introduced). 
- Ran code formatting via `pnpm format`; formatting completed successfully. 
- Pre-commit frontend hooks (lint/format) executed as part of the commit and completed (lint produced warnings but did not block commit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698216d4ba6c8330b158c84ec4390f29)