### PR TITLE
Use player+protocol+URL combos for fallback and caching

### DIFF
--- a/npm_player/packages/core/src/core/PlayerManager.ts
+++ b/npm_player/packages/core/src/core/PlayerManager.ts
@@ -667,7 +667,8 @@ export class PlayerManager {
     if (!this.cachedSelection || !newSelection) return true;
     return (
       this.cachedSelection.player !== newSelection.player ||
-      this.cachedSelection.source?.type !== newSelection.source?.type
+      this.cachedSelection.source?.type !== newSelection.source?.type ||
+      (this.cachedSelection.source?.url ?? "") !== (newSelection.source?.url ?? "")
     );
   }
 


### PR DESCRIPTION
### Motivation
- Prevent incorrect exclusion and stale selection when the same player supports multiple protocols/URLs by making fallback exclusions URL-aware. 
- Avoid reusing cached selections when only the source `url` changes to ensure fresh scoring and correct player choice. 

### Description
- Replaced `excludedPlayers` with `excludedCombos` and added `getComboKey` to form `playerShortname:protocol:url` keys in `npm_player/packages/core/src/core/PlayerManager.ts`. 
- Included source `url` in the cache key by updating `computeCacheKey` so caching is based on `type:url` pairs. 
- Switched filtering and dedupe logic to use combo keys across selection, initialization, error handling, and fallback flows and reset the `ErrorClassifier` when performing playback fallback. 

### Testing
- Ran `pnpm lint` which completed but reported existing warnings about Node engine mismatch and some `any` usages; no new lint errors were introduced. 
- Ran `pnpm format` which completed successfully. 
- No automated unit tests were added or modified as part of this change; validation was limited to lint/format checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826e17cde083308f5f5726def98085)