### PR TITLE
Fix artifact lifecycle transitions and events

### DIFF
--- a/api_balancing/internal/control/repos.go
+++ b/api_balancing/internal/control/repos.go
@@ -72,16 +72,11 @@ func (r *clipRepositoryDB) UpdateClipProgressByRequestID(ctx context.Context, re
 	if db == nil {
 		return sql.ErrConnDone
 	}
-	// Update artifact status based on progress
-	status := "processing"
-	if percent == 100 {
-		status = "ready"
-	}
 	_, err := db.ExecContext(ctx, `
 		UPDATE foghorn.artifacts
-		SET status = $2, updated_at = NOW()
+		SET status = 'processing', updated_at = NOW()
 		WHERE request_id = $1 AND artifact_type = 'clip'
-	`, requestID, status)
+	`, requestID)
 	return err
 }
 
@@ -98,6 +93,7 @@ func (r *clipRepositoryDB) UpdateClipDoneByRequestID(ctx context.Context, reques
 	_, err := db.ExecContext(ctx, `
 		UPDATE foghorn.artifacts
 		SET status = $1,
+		    manifest_path = NULLIF($2, ''),
 		    size_bytes = $3,
 		    error_message = NULLIF($4, ''),
 		    updated_at = NOW()

--- a/api_balancing/internal/control/server.go
+++ b/api_balancing/internal/control/server.go
@@ -106,6 +106,7 @@ var clipProgressHandler func(*pb.ClipProgress)
 var clipDoneHandler func(*pb.ClipDone)
 var artifactDeletedHandler func(*pb.ArtifactDeleted)
 var dvrDeletedHandler func(dvrHash string, sizeBytes uint64, nodeID string)
+var dvrStoppedHandler func(dvrHash string, finalStatus string, nodeID string, sizeBytes uint64, manifestPath string, errorMsg string)
 
 // SetClipHandlers registers callbacks for analytics emission
 func SetClipHandlers(onProgress func(*pb.ClipProgress), onDone func(*pb.ClipDone), onDeleted func(*pb.ArtifactDeleted)) {
@@ -117,6 +118,11 @@ func SetClipHandlers(onProgress func(*pb.ClipProgress), onDone func(*pb.ClipDone
 // SetDVRDeletedHandler registers callback for DVR deletion analytics
 func SetDVRDeletedHandler(handler func(dvrHash string, sizeBytes uint64, nodeID string)) {
 	dvrDeletedHandler = handler
+}
+
+// SetDVRStoppedHandler registers callback for DVR stopped analytics
+func SetDVRStoppedHandler(handler func(dvrHash string, finalStatus string, nodeID string, sizeBytes uint64, manifestPath string, errorMsg string)) {
+	dvrStoppedHandler = handler
 }
 
 // Init initializes the global registry
@@ -847,6 +853,9 @@ func processDVRStopped(stopped *pb.DVRStopped, storageNodeID string, logger logg
 	// Emit analytics for deletion (after Helmsman confirmation)
 	if finalStatus == "deleted" && dvrDeletedHandler != nil {
 		go dvrDeletedHandler(dvrHash, uint64(sizeBytes), storageNodeID)
+	}
+	if finalStatus != "deleted" && dvrStoppedHandler != nil {
+		go dvrStoppedHandler(dvrHash, finalStatus, storageNodeID, uint64(sizeBytes), manifestPath, errorMsg)
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Prevent clips being marked `ready` prematurely from progress updates and ensure the authoritative Helmsman callback controls final status.
- Persist the clip `manifest_path` on completion so storage metadata is not lost.
- Emit DVR STOPPED/FAILED lifecycle events only after Helmsman confirmation and wire missing DVR handlers so analytics are emitted reliably.
- Surface Helmsman/node/S3 cleanup errors in deletion lifecycle messages so downstream consumers can observe deferred cleanup failures.

### Description
- Changed `UpdateClipProgressByRequestID` to always keep status as `processing` and removed the `percent == 100` path so clip readiness is authoritative from `UpdateClipDoneByRequestID` (`api_balancing/internal/control/repos.go`).
- Persisted `manifest_path = NULLIF($2, '')` in `UpdateClipDoneByRequestID` so the storage path passed to the function is stored (`api_balancing/internal/control/repos.go`).
- Added a `dvrStoppedHandler` and `SetDVRStoppedHandler`, and invoke it from `processDVRStopped` for non-deleted final statuses so stopped/failed DVR lifecycle events are emitted from Helmsman confirmations (`api_balancing/internal/control/server.go`).
- Removed the immediate `StopDVR` Decklog emission and instead emit DVR stopped events from the Helmsman callback, and registered DVR stopped/deleted handlers in `handlers.Init` to emit enriched `DVRLifecycleData` (`api_balancing/internal/grpc/server.go`, `api_balancing/internal/handlers/handlers.go`).
- Capture cleanup errors when sending delete requests to nodes or S3 and attach an `Error` field to clip/DVR/VOD lifecycle messages by updating delete flows and `emit*DeletedLifecycle` helpers to accept a `cleanupError` parameter (`api_balancing/internal/grpc/server.go`).
- Ran `gofmt -w` against modified files to apply formatting.

### Testing
- Ran `gofmt -w` on modified files which completed successfully.
- Ran project lint with `make lint` which failed due to a `golangci-lint` config parsing error (`output.formats` expected a map, got slice), so CI lint could not be completed in this environment.
- No unit tests were executed in this session; further verification recommended: `make build-bin-api_balancing` and targeted unit tests such as `go test ./api_balancing/internal/control/...` and `go test ./api_balancing/internal/handlers/...`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69826d9532f08330b7886ca4e5a26848)