### PR TITLE
Make content_type optional, document VOD, improve Commodore logging, remove plan file

### DIFF
--- a/pkg/proto/periscope.proto
+++ b/pkg/proto/periscope.proto
@@ -675,12 +675,12 @@ message GetClipEventsResponse {
   repeated ClipEvent events = 2;
 }
 
-// Artifact state (current status of clips/DVR from live_artifacts table)
+// Artifact state (current status of clips/DVR/VOD from live_artifacts table)
 message ArtifactState {
   string tenant_id = 1;
-  string request_id = 2;          // clip_hash or dvr_hash
+  string request_id = 2;          // clip_hash, dvr_hash, or vod_hash
   string stream_id = 3;           // source stream
-  string content_type = 4;        // 'clip' or 'dvr'
+  string content_type = 4;        // 'clip', 'dvr', or 'vod'
   string stage = 5;               // requested, queued, processing, completed, failed, deleted
   uint32 progress_percent = 6;
   optional string error_message = 7;
@@ -701,7 +701,7 @@ message ArtifactState {
 
 message GetArtifactStateRequest {
   string tenant_id = 1;
-  string request_id = 2;          // clip_hash or dvr_hash
+  string request_id = 2;          // clip_hash, dvr_hash, or vod_hash
 }
 
 message GetArtifactStateResponse {
@@ -711,7 +711,7 @@ message GetArtifactStateResponse {
 message GetArtifactStatesRequest {
   string tenant_id = 1;
   optional string stream_id = 2;       // filter by source stream
-  optional string content_type = 3;    // filter by 'clip' or 'dvr'
+  optional string content_type = 3;    // filter by 'clip', 'dvr', or 'vod'
   optional string stage = 4;           // filter by stage
   common.CursorPaginationRequest pagination = 5;
   repeated string request_ids = 6;     // batch lookup by artifact hash (for field resolvers)


### PR DESCRIPTION
### Motivation
- Prevent accidental exclusion of DVR/VOD events by removing the default `content_type = 'clip'` behavior and making `content_type` an optional filter.
- Ensure the Periscope proto and generated docs reflect VOD support alongside `clip` and `dvr` so artifact types are clear.
- Improve observability when resolving artifact playback IDs from Commodore so lookup errors and "not found" cases are visible while debugging.
- Remove an audit plan file that should not be present in the PR to keep planning artifacts out of the repository.

### Description
- Update `GetClipEvents` in `api_analytics_query/internal/grpc/server.go` to stop defaulting `contentType` to `"clip"` and to append the `content_type = ?` clause to count and select queries only when `contentType != ""`.
- Update `pkg/proto/periscope.proto` comments and field descriptions to include `vod` alongside `clip` and `dvr` for `content_type`, `request_id`, and `ArtifactState` documentation.
- Update `api_gateway/graph/helpers.go` to import `frameworks/pkg/logging`, grab the resolver logger when available, and add debug-level structured logging for Commodore resolution errors and "not found" cases for `clip`, `dvr`, and `vod`, plus a debug log for the default fallback path.
- Remove `PLAN_CODEX_AUDIT_BACKLOG.md` from the repository to avoid including planning notes in the PR.

### Testing
- Ran `make proto`, which failed due to a missing `google/protobuf/timestamp.proto` in the sandbox so generated `.pb.go` files were not produced. (failure)
- Ran `make lint`, which failed early with a `golangci-lint` config parse error (`output.formats` expected a map). (failure)
- Ran `pnpm lint`, which completed with engine warnings and ESLint warnings but no blocking errors. (success with warnings)
- Ran `pnpm format`, which completed successfully and reformatted repository files where necessary. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698277b66d6c83309d92d059fdb669a4)