### PR TITLE
Improve disk space guards for clips and DVR

### DIFF
--- a/api_sidecar/internal/control/client.go
+++ b/api_sidecar/internal/control/client.go
@@ -439,13 +439,14 @@ func handleClipPull(logger logging.Logger, req *pb.ClipPullRequest, send func(*p
 		send(&pb.ControlMessage{SentAt: timestamppb.Now(), Payload: &pb.ControlMessage_ClipProgress{ClipProgress: &pb.ClipProgress{RequestId: requestID, Percent: 0, Message: "starting"}}})
 	}
 	if err := downloadToFile(clipURL, dst); err != nil {
+		userErr := sanitizeStorageError(err)
 		logger.WithError(err).WithFields(logging.Fields{
 			"clip_url":   clipURL,
 			"clip_hash":  clipHash,
 			"request_id": requestID,
 		}).Error("Clip pull failed")
 		if send != nil {
-			send(&pb.ControlMessage{SentAt: timestamppb.Now(), Payload: &pb.ControlMessage_ClipDone{ClipDone: &pb.ClipDone{RequestId: requestID, FilePath: dst, SizeBytes: 0, Status: "failed", Error: fmt.Sprintf("%v", err)}}})
+			send(&pb.ControlMessage{SentAt: timestamppb.Now(), Payload: &pb.ControlMessage_ClipDone{ClipDone: &pb.ClipDone{RequestId: requestID, FilePath: dst, SizeBytes: 0, Status: "failed", Error: userErr}}})
 		}
 		return
 	}
@@ -541,6 +542,13 @@ func downloadToFile(url, dst string) error {
 		return err
 	}
 	return nil
+}
+
+func sanitizeStorageError(err error) string {
+	if storage.IsInsufficientSpace(err) {
+		return "Download failed: storage node out of space"
+	}
+	return "Download failed: please retry or contact support"
 }
 
 func deriveRolesFromConfig(cfg *sidecarcfg.HelmsmanConfig) []string {


### PR DESCRIPTION
### Motivation

- Prevent DVR recordings and clip downloads from failing in obscure ways when disk is low by failing fast with a clear reason instead of propagating generic push/download errors.
- Avoid exposing internal storage details (paths, byte counts, statfs output) to end users in lifecycle events and control messages.
- Ensure clips without `Content-Length` still reserve a safe minimum so short-lived writes don't exhaust the node.

### Description

- Add a 1 GiB minimum free-space floor `MinFreeBytes` and `IsInsufficientSpace` helper in `api_sidecar/internal/storage/diskspace.go` and update `HasSpaceFor` to enforce the floor.
- Sanitize clip-side errors by adding `sanitizeStorageError` and returning a user-safe message from `handleClipPull` in `api_sidecar/internal/control/client.go` instead of the raw error.
- Add periodic disk checks in the DVR monitoring loop (`monitorJob`) in `api_sidecar/internal/control/dvr_manager.go` that stop the Mist push safely and send a sanitized DVR stopped message via `sanitizeDvrStorageError` when storage is insufficient.
- Sanitize lifecycle messages in the UI by adding `sanitizeLifecycleError` and using it for clip and DVR events in `website_application/src/routes/streams/[id]/+page.svelte` to avoid leaking internal details.

### Testing

- Ran `gofmt` on modified Go files and applied formatting successfully.
- Ran `pnpm format` which completed successfully and normalized front-end formatting.
- Ran `pnpm lint` which completed with existing workspace warnings (Node engine mismatch and `no-explicit-any` warnings) but no blocking errors for the changed files.
- Ran `make lint` which failed due to a `golangci-lint` config parsing error (`output.formats` expected a map, got a slice), unrelated to these code changes and blocking full repo linting.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69827a8e96e48330a2065d08b68a4b0d)