### PR TITLE
Support `d` day suffix in admin duration flags and clarify retention/S3 docs

### DIFF
--- a/cli/cmd/admin_test.go
+++ b/cli/cmd/admin_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import "testing"
+
+func TestNormalizeDuration(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		input       string
+		want        string
+		expectError bool
+	}{
+		{
+			name:  "empty string",
+			input: "",
+			want:  "",
+		},
+		{
+			name:  "hours preserved",
+			input: "24h",
+			want:  "24h",
+		},
+		{
+			name:  "compound duration preserved",
+			input: "1h30m",
+			want:  "1h30m",
+		},
+		{
+			name:  "days normalized to hours",
+			input: "7d",
+			want:  "168h",
+		},
+		{
+			name:  "larger days normalized to hours",
+			input: "30d",
+			want:  "720h",
+		},
+		{
+			name:        "invalid day format",
+			input:       "1.5d",
+			expectError: true,
+		},
+		{
+			name:        "zero day format",
+			input:       "0d",
+			expectError: true,
+		},
+		{
+			name:        "negative day format",
+			input:       "-1d",
+			expectError: true,
+		},
+		{
+			name:        "unknown unit",
+			input:       "5w",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := normalizeDuration(tc.input)
+			if tc.expectError {
+				if err == nil {
+					t.Fatalf("expected error for %q, got none", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if got != tc.want {
+				t.Fatalf("normalizeDuration(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

- Make CLI duration flags more user-friendly by accepting a `d` (days) suffix and normalizing it to a format parseable by `time.ParseDuration`. 
- Clarify documentation about local edge-node eviction behavior and conditional S3 cleanup so retention semantics are not misunderstood.

### Description

- Added `normalizeDuration(string) (string, error)` and updated `validateDuration` to delegate to it, converting `Nd` → `N*24h` and validating via `time.ParseDuration` in `cli/cmd/admin.go`.
- Updated admin token creation and bootstrap-token TTL handling to use the normalized duration value and adjusted CLI flag help text to include `7d` examples in `cli/cmd/admin.go`.
- Added unit tests for the normalization logic in `cli/cmd/admin_test.go` covering empty, hour, compound, day conversion and invalid inputs.
- Updated `docs/architecture/clips-dvr.md` to add an "Edge Node Disk Pressure Eviction" section and to clarify that PurgeDeletedJob S3 cleanup is conditional on S3 client and tenant resolution.

### Testing

- Ran `make lint`, which failed due to the repository's `golangci-lint` config error (`output.formats` expected a map, got slice). 
- Ran `pnpm lint`, which executed and reported existing frontend warnings (node engine mismatch warnings) but completed (no blocking errors introduced by these changes). 
- Ran `pnpm format` and `gofmt -w` to format files, and those succeeded. 
- Pre-commit hooks ran during commit and completed (formatting and go-fmt/lint steps passed in the commit run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698287bba1f88330a3a90054a44a83a1)