### PR TITLE
Gate demo mode service events across gRPC services

### DIFF
--- a/pkg/clients/commodore/grpc_client.go
+++ b/pkg/clients/commodore/grpc_client.go
@@ -61,6 +61,9 @@ func authInterceptor(serviceToken string) grpc.UnaryClientInterceptor {
 		if tenantID := ctxkeys.GetTenantID(ctx); tenantID != "" {
 			md.Set("x-tenant-id", tenantID)
 		}
+		if ctxkeys.IsDemoMode(ctx) {
+			md.Set("x-demo-mode", "true")
+		}
 
 		// Use user's JWT from context if available, otherwise fall back to service token
 		if jwtToken := ctxkeys.GetJWTToken(ctx); jwtToken != "" {

--- a/pkg/clients/purser/grpc_client.go
+++ b/pkg/clients/purser/grpc_client.go
@@ -58,6 +58,9 @@ func authInterceptor(serviceToken string) grpc.UnaryClientInterceptor {
 		if tenantID := ctxkeys.GetTenantID(ctx); tenantID != "" {
 			md.Set("x-tenant-id", tenantID)
 		}
+		if ctxkeys.IsDemoMode(ctx) {
+			md.Set("x-demo-mode", "true")
+		}
 
 		// Use user's JWT from context if available, otherwise fall back to service token
 		if jwtToken := ctxkeys.GetJWTToken(ctx); jwtToken != "" {

--- a/pkg/clients/quartermaster/grpc_client.go
+++ b/pkg/clients/quartermaster/grpc_client.go
@@ -54,6 +54,9 @@ func authInterceptor(serviceToken string) grpc.UnaryClientInterceptor {
 		if tenantID := ctxkeys.GetTenantID(ctx); tenantID != "" {
 			md.Set("x-tenant-id", tenantID)
 		}
+		if ctxkeys.IsDemoMode(ctx) {
+			md.Set("x-demo-mode", "true")
+		}
 
 		// Use user's JWT from context if available, otherwise fall back to service token
 		if jwtToken := ctxkeys.GetJWTToken(ctx); jwtToken != "" {

--- a/pkg/middleware/grpc.go
+++ b/pkg/middleware/grpc.go
@@ -68,6 +68,7 @@ func GRPCAuthInterceptor(cfg GRPCAuthConfig) grpc.UnaryServerInterceptor {
 		if !ok {
 			return nil, status.Error(codes.Unauthenticated, "missing metadata")
 		}
+		ctx = applyDemoModeMetadata(ctx, md)
 
 		// Get authorization header
 		authHeaders := md.Get("authorization")
@@ -144,6 +145,13 @@ func extractMetadataToContext(ctx context.Context, md metadata.MD, policy Servic
 	}
 	if tenantID != "" {
 		ctx = context.WithValue(ctx, ctxkeys.KeyTenantID, tenantID)
+	}
+	return ctx
+}
+
+func applyDemoModeMetadata(ctx context.Context, md metadata.MD) context.Context {
+	if value := firstMetadataValue(md.Get("x-demo-mode")); strings.EqualFold(value, "true") {
+		return context.WithValue(ctx, ctxkeys.KeyDemoMode, true)
 	}
 	return ctx
 }


### PR DESCRIPTION
### Motivation
- Prevent demo-mode requests from emitting real service events to Decklog and reduce noisy downstream traffic.
- Ensure demo mode is observable across service-to-service gRPC calls so downstream services can opt out of emitting events.

### Description
- Add `applyDemoModeMetadata` in `pkg/middleware/grpc.go` to read `x-demo-mode` from incoming metadata and set `ctxkeys.KeyDemoMode` in the request `context.Context`.
- Propagate `x-demo-mode` on outgoing gRPC calls by setting `x-demo-mode: true` when `ctxkeys.IsDemoMode(ctx)` in `pkg/clients/commodore/grpc_client.go`, `pkg/clients/purser/grpc_client.go`, and `pkg/clients/quartermaster/grpc_client.go`.
- Gate service-event emission by threading `context.Context` into `emitServiceEvent` and related helpers and returning early when `ctxkeys.IsDemoMode(ctx)` in `api_control/internal/grpc/server.go`, `api_billing/internal/grpc/server.go`, and `api_tenants/internal/grpc/server.go`, and update all call sites to pass `ctx`.
- Apply formatting/fixups (ran `gofmt` on modified files) and add necessary `frameworks/pkg/ctxkeys` imports where used.

### Testing
- Ran `gofmt -w` on modified files which completed successfully and formatted the changes.
- Ran `make lint` which failed due to a `golangci-lint` configuration error (`output.formats expected a map, got slice`) that is unrelated to these code changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69831decf1c083309c22d9bda9676261)