### PR TITLE
DLQ: preserve tenant/event headers and surface missing-tenant events

### DIFF
--- a/api_analytics_ingest/cmd/periscope/main.go
+++ b/api_analytics_ingest/cmd/periscope/main.go
@@ -119,6 +119,12 @@ func main() {
 					"source":         consumerName,
 					"original_topic": msg.Topic,
 				}
+				if tenantID, ok := msg.Headers["tenant_id"]; ok {
+					headers["tenant_id"] = tenantID
+				}
+				if eventType, ok := msg.Headers["event_type"]; ok {
+					headers["event_type"] = eventType
+				}
 
 				if produceErr := dlqProducer.ProduceMessage(dlqTopic, key, payload, headers); produceErr != nil {
 					logger.WithError(produceErr).WithFields(logging.Fields{

--- a/api_realtime/cmd/signalman/main.go
+++ b/api_realtime/cmd/signalman/main.go
@@ -107,6 +107,12 @@ func main() {
 					"source":         consumerName,
 					"original_topic": msg.Topic,
 				}
+				if tenantID, ok := msg.Headers["tenant_id"]; ok {
+					headers["tenant_id"] = tenantID
+				}
+				if eventType, ok := msg.Headers["event_type"]; ok {
+					headers["event_type"] = eventType
+				}
 
 				if produceErr := dlqProducer.ProduceMessage(dlqTopic, key, payload, headers); produceErr != nil {
 					logger.WithError(produceErr).WithFields(logging.Fields{

--- a/docs/architecture/service-events.md
+++ b/docs/architecture/service-events.md
@@ -180,6 +180,13 @@ Event types are string constants emitted by services. The list below reflects cu
 **DLQ**
 
 - Periscope Ingest and Signalman wrap Kafka handlers and publish failures to `decklog_events_dlq`.
+- DLQ payloads are JSON with base64-encoded keys/values and the original headers for replay.
+- Include `tenant_id` and `event_type` headers on DLQ messages to keep tenant-aware replay filters and routing intact.
+
+**Replay**
+
+- There is no dedicated replay service. Use Kafka tooling to consume from `decklog_events_dlq`, decode the payload, and re-publish to the original topic.
+- Preserve headers (`tenant_id`, `event_type`, etc.) when replaying so downstream enrichment behaves consistently.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Ensure analytics events missing tenant enrichment are not silently dropped so they can be triaged and replayed with tenant context. 
- Preserve `tenant_id` and `event_type` on DLQ messages so replay and header-based filtering work without re-parsing payloads. 
- Avoid noisy error logs for expected validation failures while still triggering DLQ publishing.

### Description

- Change `requireTenantID` to return an `error` and add the `errMissingTenantID` sentinel so validation failures propagate to the DLQ wrapper instead of being swallowed. 
- Update callers in `HandleAnalyticsEvent` to propagate the new error return and special-case missing-tenant errors to allow DLQ publishing without logging them as processing errors. 
- Forward original `tenant_id` and `event_type` headers when producing DLQ messages in `api_analytics_ingest/cmd/periscope/main.go` and `api_realtime/cmd/signalman/main.go`. 
- Document the DLQ payload format and replay guidance in `docs/architecture/service-events.md` and add a short plan file `PLAN_DLQ_AUDIT_FIXES.md` describing the changes.

### Testing

- Ran `make lint`, which failed due to a `golangci-lint` config decoding error (`output.formats` expected a map) so repo-wide Go linting could not complete. 
- Ran `pnpm lint`, which executed and produced engine/version warnings plus existing ESLint warnings but no new JS/TS errors introduced. 
- Ran `pnpm format`, which completed successfully. 
- Pre-commit hooks (`lefthook`) executed during commit; `go-fmt` passed and `go-lint` surfaced the same golangci-lint config error but the change was committed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698321c0f80083309d00061407dc72af)