### PR TITLE
Fix usage tracker retry handling for Decklog batches

### DIFF
--- a/api_gateway/internal/middleware/usage_tracker.go
+++ b/api_gateway/internal/middleware/usage_tracker.go
@@ -245,7 +245,8 @@ func (ut *UsageTracker) enqueueFailedBatch(event *pb.ServiceEvent, aggregateCoun
 	ut.failedBatches = append(ut.failedBatches, failedBatch{
 		event:          event,
 		aggregateCount: aggregateCount,
-		attempts:       1,
+		// attempts counts retry attempts already performed (not the initial send)
+		attempts: 0,
 	})
 	ut.failedMu.Unlock()
 }


### PR DESCRIPTION
### Motivation
- Fix a critical bug where aggregates were being reset before a send attempt, causing permanent data loss on a failed Decklog send. 
- Improve durability for transient Decklog failures by adding an in-memory retry mechanism without introducing disk-backed queues.

### Description
- Add `RetryLimit` to `UsageTrackerConfig` with a default of `3` and expose it in the startup log (`RetryLimit`).
- Introduce `failedBatch` type and `failedBatches` slice protected by `failedMu` on `UsageTracker` to hold failed batches for retries.
- Change flush flow to call `retryFailedBatches()` first, snapshot aggregates and reset counters only after snapshotting, build the `APIRequestBatch`, and use a new `sendServiceEvent` helper to centralize sending and logging.
- On send failure, enqueue the event via `enqueueFailedBatch`; implement `retryFailedBatches` to retry pending batches up to `RetryLimit` and drop with an error log after exceeding retries.
- Modified file: `api_gateway/internal/middleware/usage_tracker.go`.

### Testing
- Ran `make lint`, which failed across the repo due to the golangci-lint configuration error: `output.formats expected a map, got slice` (lint tool failure, not related to code logic changes). 
- Pre-commit checks ran `go-fmt` (success) and `go-lint` (failed with the same golangci-lint config error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698321c89bd8833093d0424a7012e260)