### PR TITLE
Enforce tenant checks for VOD relay resolution

### DIFF
--- a/api_gateway/internal/mcp/resources/vod.go
+++ b/api_gateway/internal/mcp/resources/vod.go
@@ -225,6 +225,10 @@ func resolveVodIdentifier(ctx context.Context, input string, clients *clients.Se
 		if resp == nil || !resp.Found {
 			return "", fmt.Errorf("VOD asset not found")
 		}
+		callerTenant := ctxkeys.GetTenantID(ctx)
+		if callerTenant != "" && resp.TenantId != "" && resp.TenantId != callerTenant {
+			return "", fmt.Errorf("VOD asset not found")
+		}
 		return resp.VodHash, nil
 	}
 	return input, nil

--- a/api_gateway/internal/mcp/tools/id_helpers.go
+++ b/api_gateway/internal/mcp/tools/id_helpers.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"frameworks/api_gateway/internal/clients"
+	"frameworks/pkg/ctxkeys"
 	"frameworks/pkg/globalid"
 
 	"github.com/google/uuid"
@@ -40,6 +41,10 @@ func resolveVodIdentifier(ctx context.Context, input string, clients *clients.Se
 				return "", fmt.Errorf("failed to resolve VOD relay ID: %w", err)
 			}
 			if resp == nil || !resp.Found {
+				return "", fmt.Errorf("VOD asset not found")
+			}
+			callerTenant := ctxkeys.GetTenantID(ctx)
+			if callerTenant != "" && resp.TenantId != "" && resp.TenantId != callerTenant {
 				return "", fmt.Errorf("VOD asset not found")
 			}
 			return resp.VodHash, nil


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant metadata leakage by ensuring resolved VOD relay IDs are owned by the authenticated caller when a tenant context exists.
- Implement the Phase 1 defense-in-depth fix (MCP-layer validation) to harden resolve flows without changing proto or server APIs.

### Description
- Add tenant validation using `ctxkeys.GetTenantID(ctx)` after `ResolveVodID` in `api_gateway/internal/mcp/tools/id_helpers.go` to return `VOD asset not found` when the caller tenant and resolved `TenantId` differ.
- Add the same tenant check in `api_gateway/internal/mcp/resources/vod.go` to ensure consistent behavior for MCP VOD resources. 
- Import `frameworks/pkg/ctxkeys` where required and preserve anonymous (empty tenant) behavior so public capability-based relay usage remains unchanged.

### Testing
- Ran `make lint`, which failed due to a `golangci-lint` config parsing error (`output.formats expected map, got slice`).
- Ran `make test`, which failed because `protoc-gen-go` was not available in `PATH` and proto generation aborted.
- Pre-commit hooks ran `go-fmt` successfully and attempted `go-lint` but encountered the same linter config error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69833428881c8330acd6d95d08c11ed0)