### PR TITLE
Harden x402 reconciliation during RPC outages

### DIFF
--- a/api_billing/internal/handlers/events.go
+++ b/api_billing/internal/handlers/events.go
@@ -16,6 +16,10 @@ const (
 	eventX402SettlementPending = "x402_settlement_pending"
 	eventX402SettlementFailed  = "x402_settlement_failed"
 	eventX402SettlementConfirm = "x402_settlement_confirmed"
+	eventX402RPCError          = "x402_rpc_error"
+	eventX402LateRecovery      = "x402_late_recovery"
+	eventX402AccountingAnomaly = "x402_accounting_anomaly"
+	eventX402ReorgDetected     = "x402_reorg_detected"
 )
 
 func emitBillingEvent(eventType, tenantID, resourceType, resourceID string, payload *pb.BillingEvent) {


### PR DESCRIPTION
### Motivation
- Prevent orphaned x402 settlements and incorrect accounting when RPC endpoints are unstable or down. 
- Ensure late-mined transactions (after the 2-minute access timeout) are credited to tenant balances while keeping access denied. 
- Avoid reversing confirmed settlements on transient RPC errors and signal operational issues via events. 
- Make recovery/reorg/RPC thresholds configurable so operators can tune behavior during outages.

### Description
- Added configurable parameters and error tracking to `X402Reconciler`: `recoveryWindowHours`, `reorgDepthBlocks`, `rpcErrorLimit`, `rpcErrorCounts`, and `rpcErrorMu`, and added `readEnvInt` helper to read env vars. (file: `api_billing/internal/handlers/x402_reconciler.go`)
- Extended `PendingSettlement` with `BlockNumber` and updated `NewX402Reconciler` to initialize new fields from env vars. (file: `api_billing/internal/handlers/x402_reconciler.go`)
- Extended `reconcileFailedTimeouts` to search a configurable recovery window, include reorg-related failures, require a recorded reversal before re-crediting, and emit `x402_late_recovery` and `x402_accounting_anomaly` events on successful/failed re-credit flows. (file: `api_billing/internal/handlers/x402_reconciler.go`)
- Hardened `reconcileConfirmedSettlements` to avoid marking confirmed settlements as failed on RPC instability by checking `block_number`, waiting for a configurable `reorgDepthBlocks`, and only failing on deterministic evidence (missing after depth or explicit revert), and emit `x402_reorg_detected` on reorg/revert. (file: `api_billing/internal/handlers/x402_reconciler.go`)
- Added RPC error tracking methods `trackRPCError` and `clearRPCError` that emit `x402_rpc_error` when an error threshold is reached. (file: `api_billing/internal/handlers/x402_reconciler.go`)
- Added four new billing event constants: `eventX402RPCError`, `eventX402LateRecovery`, `eventX402AccountingAnomaly`, and `eventX402ReorgDetected`. (file: `api_billing/internal/handlers/events.go`)
- Minor helpers and defensive changes: parse/handle receipts and block numbers, emit events around credit/debit flows, and applied `gofmt`.

### Testing
- Ran `gofmt -w` on modified files and applied formatting successfully. 
- Pre-commit hook (`go-lint` via lefthook) failed to load due to local config parsing error (`output.formats` expected a map, got slice), so full lint/test suite was not executed. 
- No new unit tests were added or executed in this change; the implementation plan recommends adding unit tests for recovery window parsing, RPC error counting/alerts, reorg detection, and accounting anomaly detection.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983341fc7e08330b1ce574b420e9398)