### PR TITLE
Improve MCP audit coverage

### DIFF
--- a/api_gateway/internal/mcp/server.go
+++ b/api_gateway/internal/mcp/server.go
@@ -19,6 +19,7 @@ import (
 	"frameworks/api_gateway/internal/resolvers"
 	"frameworks/pkg/ctxkeys"
 	"frameworks/pkg/logging"
+	"frameworks/pkg/tenants"
 	"frameworks/pkg/version"
 
 	"github.com/modelcontextprotocol/go-sdk/jsonrpc"
@@ -323,7 +324,7 @@ func (s *Server) registerAccessMiddleware() {
 				userID := ctxkeys.GetUserID(ctx)
 				tenantID := ctxkeys.GetTenantID(ctx)
 				if tenantID == "" {
-					tenantID = "anonymous"
+					tenantID = tenants.AnonymousTenantID.String()
 				}
 				errorCount := uint32(0)
 				if err != nil {

--- a/api_gateway/internal/middleware/usage_tracker.go
+++ b/api_gateway/internal/middleware/usage_tracker.go
@@ -220,10 +220,17 @@ func (ut *UsageTracker) flush() {
 	}
 
 	if ut.config.Decklog != nil {
-		var tenantID string
+		tenantID := ""
 		if v := ut.serviceTenantID.Load(); v != nil {
-			if s, ok := v.(string); ok {
+			if s, ok := v.(string); ok && s != "" {
 				tenantID = s
+			}
+		}
+		if tenantID == "" {
+			tenantID = tenants.SystemTenantID.String()
+			if ut.config.Logger != nil {
+				ut.config.Logger.WithField("tenant_id", tenantID).
+					Debug("Usage tracker using system tenant for service event batch")
 			}
 		}
 		event := &pb.ServiceEvent{


### PR DESCRIPTION
### Motivation

- Close audit gaps where MCP usage records and service-event batches could be emitted without valid tenant identifiers, causing dropped or unanalyzable audit rows.
- Ensure per-tenant visibility for `api_request_batch` service events so analytics can attribute usage to individual tenants.

### Description

- Normalize MCP usage recording to use the reserved anonymous tenant UUID by replacing the literal `"anonymous"` with `tenants.AnonymousTenantID.String()` in `api_gateway/internal/mcp/server.go`.
- Emit service-event batches with a valid tenant fallback by using `tenants.SystemTenantID.String()` when no service owner ID is available in `api_gateway/internal/middleware/usage_tracker.go`.
- Add `processServiceAPIRequestBatchAudit` in `api_analytics_ingest/internal/handlers/handlers.go` and wire it into the existing batch processing flow to insert one `api_events` row per-aggregate for `api_request_batch` events.
- Update the local plan `PLAN_CODEX_AUDIT_BACKLOG.md` to document the change and note the linting behavior observed in this environment.

### Testing

- Ran `make lint`, which failed due to the local `golangci-lint` configuration error `output.formats expected a map, got slice` and therefore did not complete successfully.
- Ran the repository pre-commit hooks via the commit operation (lefthook); `go-fmt` passed but `go-lint` failed with the same golangci-lint config error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698336c023d883308fe7fe00db04f86e)