### PR TITLE
Serialize HD wallet index allocation and add per-tenant x402 uniqueness safeguard

### DIFF
--- a/pkg/database/sql/schema/purser.sql
+++ b/pkg/database/sql/schema/purser.sql
@@ -582,6 +582,9 @@ CREATE INDEX IF NOT EXISTS idx_purser_webhook_events_provider ON purser.webhook_
 
 -- Per-tenant x402 address index (reuse same address across payments)
 ALTER TABLE purser.tenant_subscriptions ADD COLUMN IF NOT EXISTS x402_address_index INTEGER;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_tenant_subscriptions_x402_address_index
+    ON purser.tenant_subscriptions(x402_address_index)
+    WHERE x402_address_index IS NOT NULL;
 
 -- Nonce tracking to prevent replay attacks
 -- Each EIP-3009 authorization has a unique nonce that can only be used once


### PR DESCRIPTION
### Motivation
- Prevent concurrent allocation races that could assign the same HD derivation index to multiple tenants or consume indexes on failed wallet inserts.
- Make index allocation atomic with inserts to avoid leaking reserved indexes and to centralize the "skip index 0" rule.
- Add a schema-level safety net to prevent accidental duplicate tenant x402 indexes.

### Description
- Add transaction-aware allocators: `GetNextDerivationIndexTx` and `GetNextNonZeroDerivationIndexTx` in `api_billing/internal/handlers/hdwallet.go` and make `GetNextDerivationIndex` delegate to the tx-aware helper.
- Make `GenerateDepositAddress` allocate the derivation index inside a single transaction and use `tx.Exec` for the `INSERT` so index increments roll back on failure (`api_billing/internal/handlers/hdwallet.go`).
- Serialize per-tenant deposit address allocation by wrapping `GetTenantDepositAddress` in a transaction and using `SELECT ... FOR UPDATE` on the tenant row, then update the tenant row inside the same tx (`api_billing/internal/handlers/x402.go`).
- Add a partial unique index `idx_tenant_subscriptions_x402_address_index` to `pkg/database/sql/schema/purser.sql` to enforce unique non-null `x402_address_index` values across tenants as a safety net.

### Testing
- Ran `gofmt` which completed successfully on the modified files.
- Ran `make lint` which failed due to a `golangci-lint` config error (`output.formats` expected a map), preventing full Go lint verification.
- Ran `pnpm lint` which completed but reported existing frontend warnings and a node engine warning (no new frontend errors introduced by these changes).
- Ran `pnpm format` which completed (Prettier ran across the workspace).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698336cfa4e883309b484e14b1379b4d)