### PR TITLE
Validate artifact playback content types and hashes

### DIFF
--- a/api_balancing/internal/control/playback.go
+++ b/api_balancing/internal/control/playback.go
@@ -41,8 +41,14 @@ func ResolveContent(ctx context.Context, input string) (*ContentResolution, erro
 	// 1. Artifact playback_id (clip/dvr/vod)
 	if CommodoreClient != nil {
 		if resp, err := CommodoreClient.ResolveArtifactPlaybackID(ctx, input); err == nil && resp.Found {
+			contentType := strings.ToLower(strings.TrimSpace(resp.ContentType))
+			switch contentType {
+			case "clip", "dvr", "vod":
+			default:
+				return nil, fmt.Errorf("invalid artifact content_type %q", resp.ContentType)
+			}
 			res := &ContentResolution{
-				ContentType:  resp.ContentType,
+				ContentType:  contentType,
 				ContentId:    input,
 				TenantId:     resp.TenantId,
 				StreamId:     resp.StreamId,

--- a/api_gateway/graph/helpers.go
+++ b/api_gateway/graph/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"frameworks/api_gateway/internal/loaders"
 	gwmiddleware "frameworks/api_gateway/internal/middleware"
+	"frameworks/pkg/clips"
 	"frameworks/pkg/logging"
 	"frameworks/pkg/middleware"
 	pb "frameworks/pkg/proto"
@@ -65,6 +66,12 @@ func (r *dVRRequestResolver) getLifecycleData(ctx context.Context, requestID str
 // Best-effort: returns nil on lookup errors or missing mappings.
 func (r *Resolver) resolveArtifactPlaybackID(ctx context.Context, contentType, hash string) *string {
 	if hash == "" || gwmiddleware.IsDemoMode(ctx) || r == nil || r.Resolver == nil || r.Resolver.Clients == nil || r.Resolver.Clients.Commodore == nil {
+		return nil
+	}
+	if !clips.ValidateClipHash(hash) {
+		if r.Resolver.Logger != nil {
+			r.Resolver.Logger.WithField("content_type", contentType).WithField("hash", hash).Debug("Skipping artifact playback resolution: invalid hash format")
+		}
 		return nil
 	}
 


### PR DESCRIPTION
### Motivation

- Prevent inconsistent routing when Commodore returns an unexpected `content_type` by normalizing and validating artifact types before using them for artifact resolution.
- Avoid running Commodore artifact hash lookups for non-hash `request_id` values by skipping resolution early and emitting a debug log.

### Description

- Normalize `resp.ContentType` with `strings.ToLower(strings.TrimSpace(...))` and allow only `"clip"`, `"dvr"`, or `"vod"`, returning an error for any other artifact type in `api_balancing/internal/control/playback.go`.
- Set the resolved `ContentType` to the normalized value to ensure consistent downstream routing in `ResolveContent`.
- Add an early `ValidateClipHash` check (from `frameworks/pkg/clips`) in `api_gateway/graph/helpers.go` to skip artifact playback ID lookups when the hash format is invalid and emit a debug log when a logger is available.
- Modified files: `api_balancing/internal/control/playback.go` and `api_gateway/graph/helpers.go` and added the necessary imports for `strings` and `frameworks/pkg/clips`.

### Testing

- Ran `make lint` which failed due to a golangci-lint configuration error: `output.formats expected a map, got slice`.
- Pre-commit hooks ran; `go-fmt` passed but `go-lint` surfaced the same golangci-lint config error reported by `make lint`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983520f47a483309d0078ee171b3374)