### PR TITLE
Add webhook router allowlist tests

### DIFF
--- a/api_gateway/internal/webhooks/router_test.go
+++ b/api_gateway/internal/webhooks/router_test.go
@@ -1,0 +1,68 @@
+package webhooks
+
+import "testing"
+
+func TestIsProviderAllowed(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		service  string
+		provider string
+		allowed  bool
+	}{
+		{
+			name:     "billing stripe",
+			service:  "billing",
+			provider: "stripe",
+			allowed:  true,
+		},
+		{
+			name:     "billing mollie",
+			service:  "billing",
+			provider: "mollie",
+			allowed:  true,
+		},
+		{
+			name:     "billing unknown provider",
+			service:  "billing",
+			provider: "paypal",
+			allowed:  false,
+		},
+		{
+			name:     "unknown service",
+			service:  "payments",
+			provider: "stripe",
+			allowed:  false,
+		},
+		{
+			name:     "empty service",
+			service:  "",
+			provider: "stripe",
+			allowed:  false,
+		},
+		{
+			name:     "empty provider",
+			service:  "billing",
+			provider: "",
+			allowed:  false,
+		},
+		{
+			name:     "empty service and provider",
+			service:  "",
+			provider: "",
+			allowed:  false,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isProviderAllowed(tc.service, tc.provider); got != tc.allowed {
+				t.Fatalf("isProviderAllowed(%q, %q) = %v, want %v", tc.service, tc.provider, got, tc.allowed)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Add unit tests to cover the webhook router allowlist logic for `isProviderAllowed` so regressions in provider/service validation are caught early.

### Description
- Add `api_gateway/internal/webhooks/router_test.go` with a table-driven test for `isProviderAllowed` covering the seven cases (billing+stripe, billing+mollie, billing+paypal, payments+stripe, empty service, empty provider, both empty) and using `t.Parallel()` for subtests.

### Testing
- Ran `go test -v ./api_gateway/internal/webhooks/...`, which failed with: `directory prefix api_gateway/internal/webhooks does not contain main module or its selected dependencies` indicating the test run could not resolve the module context.
- A pre-commit hook reported a `go-lint` config decode error for `output.formats` during the commit, but the commit completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698386169cbc8330ba0b8a415a0c3922)