### PR TITLE
Add ctxkeys for GraphQL metadata and x402 paid flag; replace string Gin keys

### DIFF
--- a/api_gateway/cmd/bridge/main.go
+++ b/api_gateway/cmd/bridge/main.go
@@ -158,15 +158,15 @@ func main() {
 		resp := next(ctx)
 		if resp != nil {
 			if ginCtx, ok := ctx.Value(ctxkeys.KeyGinContext).(*gin.Context); ok && ginCtx != nil {
-				ginCtx.Set("graphql_error_count", len(resp.Errors))
+				ginCtx.Set(string(ctxkeys.KeyGraphQLErrorCount), len(resp.Errors))
 				if graphql.HasOperationContext(ctx) {
 					if opCtx := graphql.GetOperationContext(ctx); opCtx.Operation != nil {
-						ginCtx.Set("graphql_operation_type", string(opCtx.Operation.Operation))
-						ginCtx.Set("graphql_operation_name", opCtx.Operation.Name)
+						ginCtx.Set(string(ctxkeys.KeyGraphQLOperationType), string(opCtx.Operation.Operation))
+						ginCtx.Set(string(ctxkeys.KeyGraphQLOperationName), opCtx.Operation.Name)
 					}
 				}
 				if stats := extension.GetComplexityStats(ctx); stats != nil {
-					ginCtx.Set("graphql_complexity", stats.Complexity)
+					ginCtx.Set(string(ctxkeys.KeyGraphQLComplexity), stats.Complexity)
 				}
 			}
 		}

--- a/api_gateway/internal/middleware/graphql.go
+++ b/api_gateway/internal/middleware/graphql.go
@@ -51,18 +51,18 @@ func GraphQLContextMiddleware() gin.HandlerFunc {
 		var authenticated bool
 
 		// Try Gin context first (HTTP requests)
-		if userIDVal, exists := c.Get("user_id"); exists {
+		if userIDVal, exists := c.Get(string(ctxkeys.KeyUserID)); exists {
 			if userIDStr, authenticated = userIDVal.(string); authenticated {
-				if v, ok := c.Get("tenant_id"); ok {
+				if v, ok := c.Get(string(ctxkeys.KeyTenantID)); ok {
 					tenantIDStr, _ = v.(string)
 				}
-				if v, ok := c.Get("email"); ok {
+				if v, ok := c.Get(string(ctxkeys.KeyEmail)); ok {
 					emailStr, _ = v.(string)
 				}
-				if v, ok := c.Get("role"); ok {
+				if v, ok := c.Get(string(ctxkeys.KeyRole)); ok {
 					roleStr, _ = v.(string)
 				}
-				if v, ok := c.Get("permissions"); ok {
+				if v, ok := c.Get(string(ctxkeys.KeyPermissions)); ok {
 					permissions, _ = v.([]string)
 				}
 			}

--- a/api_gateway/internal/middleware/graphql_test.go
+++ b/api_gateway/internal/middleware/graphql_test.go
@@ -1,0 +1,121 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"frameworks/pkg/ctxkeys"
+
+	"github.com/gin-gonic/gin"
+)
+
+func TestGraphQLContextMiddleware_GinToGoContextBridge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		name       string
+		ginSetup   func(c *gin.Context)
+		wantUserID string
+		wantTenant string
+		wantEmail  string
+		wantRole   string
+	}{
+		{
+			name: "bridges all user fields from Gin to Go context",
+			ginSetup: func(c *gin.Context) {
+				c.Set(string(ctxkeys.KeyUserID), "user-123")
+				c.Set(string(ctxkeys.KeyTenantID), "tenant-456")
+				c.Set(string(ctxkeys.KeyEmail), "test@example.com")
+				c.Set(string(ctxkeys.KeyRole), "admin")
+			},
+			wantUserID: "user-123",
+			wantTenant: "tenant-456",
+			wantEmail:  "test@example.com",
+			wantRole:   "admin",
+		},
+		{
+			name: "handles missing optional fields",
+			ginSetup: func(c *gin.Context) {
+				c.Set(string(ctxkeys.KeyUserID), "user-789")
+				c.Set(string(ctxkeys.KeyTenantID), "tenant-xyz")
+			},
+			wantUserID: "user-789",
+			wantTenant: "tenant-xyz",
+			wantEmail:  "",
+			wantRole:   "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedUserID, capturedTenant, capturedEmail, capturedRole string
+
+			r := gin.New()
+			// First middleware sets Gin context (simulating auth middleware)
+			r.Use(func(c *gin.Context) {
+				tt.ginSetup(c)
+				c.Next()
+			})
+			// GraphQL middleware bridges to Go context
+			r.Use(GraphQLContextMiddleware())
+			// Handler verifies Go context has the values
+			r.GET("/test", func(c *gin.Context) {
+				ctx := c.Request.Context()
+				if v := ctx.Value(ctxkeys.KeyUserID); v != nil {
+					capturedUserID, _ = v.(string)
+				}
+				if v := ctx.Value(ctxkeys.KeyTenantID); v != nil {
+					capturedTenant, _ = v.(string)
+				}
+				if v := ctx.Value(ctxkeys.KeyEmail); v != nil {
+					capturedEmail, _ = v.(string)
+				}
+				if v := ctx.Value(ctxkeys.KeyRole); v != nil {
+					capturedRole, _ = v.(string)
+				}
+				c.String(200, "ok")
+			})
+
+			w := httptest.NewRecorder()
+			req, _ := http.NewRequestWithContext(context.Background(), "GET", "/test", nil)
+			r.ServeHTTP(w, req)
+
+			if capturedUserID != tt.wantUserID {
+				t.Errorf("UserID: got %q, want %q", capturedUserID, tt.wantUserID)
+			}
+			if capturedTenant != tt.wantTenant {
+				t.Errorf("TenantID: got %q, want %q", capturedTenant, tt.wantTenant)
+			}
+			if capturedEmail != tt.wantEmail {
+				t.Errorf("Email: got %q, want %q", capturedEmail, tt.wantEmail)
+			}
+			if capturedRole != tt.wantRole {
+				t.Errorf("Role: got %q, want %q", capturedRole, tt.wantRole)
+			}
+		})
+	}
+}
+
+func TestCtxkeysStringCastConsistency(t *testing.T) {
+	// Verify that ctxkeys constants have expected string values
+	// This catches accidental changes to key values
+	tests := []struct {
+		key  ctxkeys.Key
+		want string
+	}{
+		{ctxkeys.KeyUserID, "user_id"},
+		{ctxkeys.KeyTenantID, "tenant_id"},
+		{ctxkeys.KeyEmail, "email"},
+		{ctxkeys.KeyRole, "role"},
+		{ctxkeys.KeyJWTToken, "jwt_token"},
+		{ctxkeys.KeyPermissions, "permissions"},
+	}
+
+	for _, tt := range tests {
+		if string(tt.key) != tt.want {
+			t.Errorf("ctxkeys.%v = %q, want %q", tt.key, string(tt.key), tt.want)
+		}
+	}
+}

--- a/api_gateway/internal/middleware/public_or_jwt.go
+++ b/api_gateway/internal/middleware/public_or_jwt.go
@@ -52,11 +52,11 @@ func RequireJWTAuth(secret []byte) gin.HandlerFunc {
 		}
 
 		// Set user context for downstream handlers
-		c.Set("user_id", claims.UserID)
-		c.Set("tenant_id", claims.TenantID)
-		c.Set("email", claims.Email)
-		c.Set("role", claims.Role)
-		c.Set("auth_type", "jwt")
+		c.Set(string(ctxkeys.KeyUserID), claims.UserID)
+		c.Set(string(ctxkeys.KeyTenantID), claims.TenantID)
+		c.Set(string(ctxkeys.KeyEmail), claims.Email)
+		c.Set(string(ctxkeys.KeyRole), claims.Role)
+		c.Set(string(ctxkeys.KeyAuthType), "jwt")
 
 		// Also set in request context for gRPC client interceptor
 		ctx := c.Request.Context()
@@ -118,7 +118,7 @@ func PublicOrJWTAuth(secret []byte, serviceClients *clients.ServiceClients) gin.
 
 			// If allowlisted, proceed anonymously (ignore any tokens sent)
 			if isAllowlistedQuery(body) {
-				c.Set("public_allowlisted", true)
+				c.Set(string(ctxkeys.KeyPublicAllowlisted), true)
 				ctx := context.WithValue(c.Request.Context(), ctxkeys.KeyPublicAllowlisted, true)
 				c.Request = c.Request.WithContext(ctx)
 				c.Next()
@@ -159,22 +159,22 @@ func PublicOrJWTAuth(secret []byte, serviceClients *clients.ServiceClients) gin.
 			}
 		}
 
-		c.Set("user_id", authResult.UserID)
-		c.Set("tenant_id", authResult.TenantID)
-		c.Set("email", authResult.Email)
-		c.Set("role", authResult.Role)
-		c.Set("auth_type", authResult.AuthType)
+		c.Set(string(ctxkeys.KeyUserID), authResult.UserID)
+		c.Set(string(ctxkeys.KeyTenantID), authResult.TenantID)
+		c.Set(string(ctxkeys.KeyEmail), authResult.Email)
+		c.Set(string(ctxkeys.KeyRole), authResult.Role)
+		c.Set(string(ctxkeys.KeyAuthType), authResult.AuthType)
 		if authResult.AuthType == "x402" {
-			c.Set("x402_processed", authResult.X402Processed)
-			c.Set("x402_auth_only", authResult.X402AuthOnly)
+			c.Set(string(ctxkeys.KeyX402Processed), authResult.X402Processed)
+			c.Set(string(ctxkeys.KeyX402AuthOnly), authResult.X402AuthOnly)
 		}
 		if authResult.AuthType == "api_token" {
 			tokenID := authResult.TokenID
 			if tokenID == "" {
 				tokenID = authResult.APIToken
 			}
-			c.Set("api_token_hash", hashIdentifier(tokenID))
-			c.Set("permissions", authResult.Permissions)
+			c.Set(string(ctxkeys.KeyAPITokenHash), hashIdentifier(tokenID))
+			c.Set(string(ctxkeys.KeyPermissions), authResult.Permissions)
 		}
 
 		ctx := ApplyAuthToContext(c.Request.Context(), authResult)

--- a/api_gateway/internal/middleware/ratelimit.go
+++ b/api_gateway/internal/middleware/ratelimit.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"time"
 
+	"frameworks/pkg/ctxkeys"
 	"frameworks/pkg/globalid"
 	"frameworks/pkg/logging"
 	pb "frameworks/pkg/proto"
@@ -266,22 +267,22 @@ type graphqlRequest struct {
 // rateLimitMiddlewareInternal is the internal implementation with optional x402 support
 func rateLimitMiddlewareInternal(rl *RateLimiter, getLimits func(tenantID string) (limit, burst int), billingChecker BillingChecker, x402Provider X402Provider, x402Settler X402Settler, x402Resolver x402.CommodoreClient) gin.HandlerFunc {
 	return func(c *gin.Context) {
-		tenantID, _ := c.Get("tenant_id")
+		tenantID, _ := c.Get(string(ctxkeys.KeyTenantID))
 		tenantIDStr, _ := tenantID.(string)
 		publicAllowlisted := false
 		x402Processed := false
 		x402AuthOnly := false
-		if v, ok := c.Get("public_allowlisted"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyPublicAllowlisted)); ok {
 			if allowed, ok := v.(bool); ok {
 				publicAllowlisted = allowed
 			}
 		}
-		if v, ok := c.Get("x402_processed"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyX402Processed)); ok {
 			if processed, ok := v.(bool); ok {
 				x402Processed = processed
 			}
 		}
-		if v, ok := c.Get("x402_auth_only"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyX402AuthOnly)); ok {
 			if authOnly, ok := v.(bool); ok {
 				x402AuthOnly = authOnly
 			}

--- a/api_gateway/internal/middleware/usage_tracker.go
+++ b/api_gateway/internal/middleware/usage_tracker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"frameworks/pkg/clients/decklog"
+	"frameworks/pkg/ctxkeys"
 	"frameworks/pkg/logging"
 	pb "frameworks/pkg/proto"
 	"frameworks/pkg/tenants"
@@ -384,7 +385,7 @@ func UsageTrackerMiddleware(tracker *UsageTracker) gin.HandlerFunc {
 
 		// Get tenant ID from context
 		tenantID := ""
-		if tid, exists := c.Get("tenant_id"); exists {
+		if tid, exists := c.Get(string(ctxkeys.KeyTenantID)); exists {
 			if s, ok := tid.(string); ok {
 				tenantID = s
 			}
@@ -395,26 +396,26 @@ func UsageTrackerMiddleware(tracker *UsageTracker) gin.HandlerFunc {
 
 		// Determine auth type
 		authType := "anonymous"
-		if v, ok := c.Get("auth_type"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyAuthType)); ok {
 			if s, ok := v.(string); ok && s != "" {
 				authType = s
 			}
-		} else if _, exists := c.Get("jwt_token"); exists {
+		} else if _, exists := c.Get(string(ctxkeys.KeyJWTToken)); exists {
 			authType = "jwt"
-		} else if _, exists := c.Get("api_token"); exists {
+		} else if _, exists := c.Get(string(ctxkeys.KeyAPIToken)); exists {
 			authType = "api_token"
-		} else if _, exists := c.Get("wallet_address"); exists {
+		} else if _, exists := c.Get(string(ctxkeys.KeyWalletAddr)); exists {
 			authType = "wallet"
 		}
 
 		userID := ""
-		if v, ok := c.Get("user_id"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyUserID)); ok {
 			if s, ok := v.(string); ok {
 				userID = s
 			}
 		}
 		var tokenHash uint64
-		if v, ok := c.Get("api_token_hash"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyAPITokenHash)); ok {
 			switch t := v.(type) {
 			case uint64:
 				tokenHash = t
@@ -436,12 +437,12 @@ func UsageTrackerMiddleware(tracker *UsageTracker) gin.HandlerFunc {
 		opName := ""
 		complexity := uint32(0)
 
-		if v, ok := c.Get("graphql_operation_type"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyGraphQLOperationType)); ok {
 			if s, ok := v.(string); ok && s != "" {
 				opType = s
 			}
 		}
-		if v, ok := c.Get("graphql_operation_name"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyGraphQLOperationName)); ok {
 			if s, ok := v.(string); ok {
 				opName = s
 			}
@@ -458,7 +459,7 @@ func UsageTrackerMiddleware(tracker *UsageTracker) gin.HandlerFunc {
 			}
 		}
 
-		if v, ok := c.Get("graphql_complexity"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyGraphQLComplexity)); ok {
 			switch t := v.(type) {
 			case int:
 				if t > 0 {
@@ -484,7 +485,7 @@ func UsageTrackerMiddleware(tracker *UsageTracker) gin.HandlerFunc {
 		}
 
 		var errorCount uint32
-		if v, ok := c.Get("graphql_error_count"); ok {
+		if v, ok := c.Get(string(ctxkeys.KeyGraphQLErrorCount)); ok {
 			switch t := v.(type) {
 			case int:
 				if t > 0 {

--- a/api_gateway/internal/middleware/viewer_x402.go
+++ b/api_gateway/internal/middleware/viewer_x402.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"frameworks/api_gateway/internal/clients"
+	"frameworks/pkg/ctxkeys"
 	"frameworks/pkg/logging"
 	x402 "frameworks/pkg/x402"
 
@@ -101,7 +102,7 @@ func ViewerX402Middleware(serviceClients *clients.ServiceClients, logger logging
 				return
 			}
 			if settleResult != nil {
-				c.Set("x402_paid", true)
+				c.Set(string(ctxkeys.KeyX402Paid), true)
 				x402Paid = true
 			}
 		}

--- a/api_gateway/internal/resolvers/resolver.go
+++ b/api_gateway/internal/resolvers/resolver.go
@@ -98,7 +98,7 @@ func (r *Resolver) DoResolveViewerEndpoint(ctx context.Context, contentID string
 	x402Paid := false
 	if ginCtx, ok := ctx.Value(ctxkeys.KeyGinContext).(*gin.Context); ok && ginCtx != nil {
 		httpReq = ginCtx.Request
-		if v, ok := ginCtx.Get("x402_paid"); ok {
+		if v, ok := ginCtx.Get(string(ctxkeys.KeyX402Paid)); ok {
 			if paid, ok := v.(bool); ok {
 				x402Paid = paid
 			}

--- a/cli/cmd/admin.go
+++ b/cli/cmd/admin.go
@@ -15,6 +15,7 @@ import (
 	fwcfg "frameworks/cli/internal/config"
 	commodore "frameworks/pkg/clients/commodore"
 	qmclient "frameworks/pkg/clients/quartermaster"
+	"frameworks/pkg/ctxkeys"
 	"frameworks/pkg/logging"
 	pb "frameworks/pkg/proto"
 	"github.com/google/uuid"
@@ -469,7 +470,7 @@ func newAdminBootstrapTokensCreateCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 		resp, err := qm.CreateBootstrapToken(cctx, req)
 		if err != nil {
@@ -503,7 +504,7 @@ func newAdminBootstrapTokensListCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 		resp, err := qm.ListBootstrapTokens(cctx, "", "", nil)
 		if err != nil {
@@ -546,7 +547,7 @@ func newAdminBootstrapTokensRevokeCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		var tokenID string
@@ -616,7 +617,7 @@ func newAdminTenantsListCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 		resp, err := qm.ListTenants(cctx, nil)
 		if err != nil {
@@ -658,7 +659,7 @@ func newAdminClustersListCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 		resp, err := qm.ListClusters(cctx, nil)
 		if err != nil {
@@ -723,7 +724,7 @@ func newAdminClustersCreateCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		req := &pb.CreateClusterRequest{
@@ -812,7 +813,7 @@ func newAdminClustersUpdateCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		req := &pb.UpdateClusterRequest{
@@ -919,7 +920,7 @@ func newAdminClustersAccessListCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 		resp, err := qm.ListClustersForTenant(cctx, tenantID, nil)
 		if err != nil {
@@ -977,7 +978,7 @@ func newAdminClustersAccessGrantCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		req := &pb.GrantClusterAccessRequest{
@@ -1049,7 +1050,7 @@ func newAdminClustersInvitesCreateCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		req := &pb.CreateClusterInviteRequest{
@@ -1104,7 +1105,7 @@ func newAdminClustersInvitesListCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		resp, err := qm.ListClusterInvites(cctx, &pb.ListClusterInvitesRequest{
@@ -1156,7 +1157,7 @@ func newAdminClustersInvitesRevokeCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		if err := qm.RevokeClusterInvite(cctx, &pb.RevokeClusterInviteRequest{
@@ -1189,7 +1190,7 @@ func newAdminClustersInvitesListMineCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		resp, err := qm.ListMyClusterInvites(cctx, &pb.ListMyClusterInvitesRequest{
@@ -1238,7 +1239,7 @@ func newAdminClustersInvitesAcceptCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		resp, err := qm.AcceptClusterInvite(cctx, &pb.AcceptClusterInviteRequest{
@@ -1284,7 +1285,7 @@ func newAdminClustersSubscriptionsListCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 		resp, err := qm.ListMySubscriptions(cctx, &pb.ListMySubscriptionsRequest{TenantId: tenantID})
 		if err != nil {
@@ -1328,7 +1329,7 @@ func newAdminNodesListCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 		resp, err := qm.ListNodes(cctx, clusterID, nodeType, region, nil)
 		if err != nil {
@@ -1419,7 +1420,7 @@ func newAdminNodesCreateCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 
 		req := &pb.CreateNodeRequest{
@@ -1513,7 +1514,7 @@ func newAdminNodesHardwareCmd() *cobra.Command {
 		cctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 		defer cancel()
 		if ctxCfg.Auth.JWT != "" {
-			cctx = context.WithValue(cctx, "jwt_token", ctxCfg.Auth.JWT)
+			cctx = context.WithValue(cctx, ctxkeys.KeyJWTToken, ctxCfg.Auth.JWT)
 		}
 		req := &pb.UpdateNodeHardwareRequest{
 			NodeId: nodeID,

--- a/pkg/auth/middleware.go
+++ b/pkg/auth/middleware.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"strings"
 
+	"frameworks/pkg/ctxkeys"
 	"github.com/gin-gonic/gin"
 )
 
@@ -69,10 +70,10 @@ func JWTAuthMiddleware(secret []byte) gin.HandlerFunc {
 		claims, err := ValidateJWT(token, secret)
 		if err == nil {
 			// JWT is valid - set user claims in context
-			c.Set("user_id", claims.UserID)
-			c.Set("tenant_id", claims.TenantID)
-			c.Set("email", claims.Email)
-			c.Set("role", claims.Role)
+			c.Set(string(ctxkeys.KeyUserID), claims.UserID)
+			c.Set(string(ctxkeys.KeyTenantID), claims.TenantID)
+			c.Set(string(ctxkeys.KeyEmail), claims.Email)
+			c.Set(string(ctxkeys.KeyRole), claims.Role)
 			c.Next()
 			return
 		}
@@ -81,10 +82,10 @@ func JWTAuthMiddleware(secret []byte) gin.HandlerFunc {
 		serviceToken := GetServiceToken()
 		if serviceToken != "" && ValidateServiceToken(token, serviceToken) == nil {
 			// Service token is valid - set service account claims in context
-			c.Set("user_id", "00000000-0000-0000-0000-000000000000")   // Service account UUID
-			c.Set("tenant_id", "00000000-0000-0000-0000-000000000001") // System tenant
-			c.Set("email", "service@internal")
-			c.Set("role", "service")
+			c.Set(string(ctxkeys.KeyUserID), "00000000-0000-0000-0000-000000000000")   // Service account UUID
+			c.Set(string(ctxkeys.KeyTenantID), "00000000-0000-0000-0000-000000000001") // System tenant
+			c.Set(string(ctxkeys.KeyEmail), "service@internal")
+			c.Set(string(ctxkeys.KeyRole), "service")
 			c.Next()
 			return
 		}

--- a/pkg/auth/middleware_test.go
+++ b/pkg/auth/middleware_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"frameworks/pkg/ctxkeys"
 	"github.com/gin-gonic/gin"
 )
 
@@ -50,7 +51,7 @@ func TestJWTAuthMiddleware(t *testing.T) {
 	r := gin.New()
 	r.Use(JWTAuthMiddleware(secret))
 	r.GET("/ok", func(c *gin.Context) {
-		if c.GetString("user_id") != "u1" || c.GetString("tenant_id") != "t1" {
+		if c.GetString(string(ctxkeys.KeyUserID)) != "u1" || c.GetString(string(ctxkeys.KeyTenantID)) != "t1" {
 			t.Fatalf("claims not set")
 		}
 		c.String(200, "ok")

--- a/pkg/ctxkeys/keys.go
+++ b/pkg/ctxkeys/keys.go
@@ -31,6 +31,7 @@ const (
 	KeyX402Processed Key = "x402_processed"
 	KeyX402AuthOnly  Key = "x402_auth_only"
 	KeyXPayment      Key = "x_payment"
+	KeyX402Paid      Key = "x402_paid"
 )
 
 // Request context keys
@@ -52,12 +53,16 @@ const (
 
 // Misc context keys
 const (
-	KeyGinContext        Key = "GinContext"
-	KeyPublicAllowlisted Key = "public_allowlisted"
-	KeyLoaders           Key = "loaders"
-	KeyWSCookieToken     Key = "ws_cookie_token"
-	KeyHTTPRequest       Key = "http_request"
-	KeyCapability        Key = "cap"
+	KeyGinContext           Key = "GinContext"
+	KeyPublicAllowlisted    Key = "public_allowlisted"
+	KeyLoaders              Key = "loaders"
+	KeyWSCookieToken        Key = "ws_cookie_token"
+	KeyHTTPRequest          Key = "http_request"
+	KeyCapability           Key = "cap"
+	KeyGraphQLOperationType Key = "graphql_operation_type"
+	KeyGraphQLOperationName Key = "graphql_operation_name"
+	KeyGraphQLComplexity    Key = "graphql_complexity"
+	KeyGraphQLErrorCount    Key = "graphql_error_count"
 )
 
 // GetTenantID extracts tenant_id from context.

--- a/pkg/middleware/middleware.go
+++ b/pkg/middleware/middleware.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"time"
 
+	"frameworks/pkg/ctxkeys"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 
@@ -28,8 +29,8 @@ func LoggingMiddleware(logger logging.Logger) gin.HandlerFunc {
 			"latency":    time.Since(start),
 			"client_ip":  c.ClientIP(),
 			"user_agent": c.Request.UserAgent(),
-			"tenant_id":  c.GetString("tenant_id"),
-			"user_id":    c.GetString("user_id"),
+			"tenant_id":  c.GetString(string(ctxkeys.KeyTenantID)),
+			"user_id":    c.GetString(string(ctxkeys.KeyUserID)),
 		}).Info("HTTP request")
 	}
 }


### PR DESCRIPTION
### Motivation
- Centralize and type Gin/request context keys to avoid unsafe string literals and collisions, and to make GraphQL and x402 metadata available consistently across HTTP middleware, resolvers and CLI gRPC callers.
- Introduce explicit keys for GraphQL operation metadata and the x402 paid flag so gqlgen hooks, usage tracking, viewer middleware and resolvers use a single canonical source of truth.

### Description
- Added new typed keys in `pkg/ctxkeys/keys.go` for GraphQL metadata (`KeyGraphQLOperationType`, `KeyGraphQLOperationName`, `KeyGraphQLComplexity`, `KeyGraphQLErrorCount`) and `KeyX402Paid` for x402 paid state.
- Updated GraphQL bridge hooks to write operation metadata and complexity to Gin context using `ctxkeys` in `api_gateway/cmd/bridge/main.go`.
- Updated usage tracking to read GraphQL metadata from Gin using `ctxkeys` in `api_gateway/internal/middleware/usage_tracker.go`.
- Standardized x402 paid flag storage/lookup to `ctxkeys` in `api_gateway/internal/middleware/viewer_x402.go` and `api_gateway/internal/resolvers/resolver.go`.
- Replaced remaining ad-hoc string Gin/context keys with `ctxkeys` across middleware and helper packages including `api_gateway/internal/middleware/graphql.go`, `api_gateway/internal/middleware/public_or_jwt.go`, `api_gateway/internal/middleware/ratelimit.go`, `pkg/auth/middleware.go`, `pkg/middleware/middleware.go`, and CLI gRPC context forwarding in `cli/cmd/admin.go`.
- Updated `pkg/auth/middleware_test.go` to assert against the new `ctxkeys` usage.

### Testing
- Ran `gofmt -w` on modified files to ensure formatting, which completed successfully.
- Invoked repository lint via `make lint` and pre-commit hooks, both of which failed due to a `golangci-lint` configuration parsing error: `output.formats expected a map, got slice` (this prevented a full lint pass).
- No other automated test failures introduced by these changes were observed during the local checks performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983829a12708330ab2f6ce4d7693d36)