### PR TITLE
Add unit tests for playback, S3, HD wallet, validation, and billing helpers

### DIFF
--- a/api_analytics_query/internal/handlers/billing_test.go
+++ b/api_analytics_query/internal/handlers/billing_test.go
@@ -1,0 +1,36 @@
+package handlers
+
+import (
+	"math"
+	"testing"
+)
+
+func TestSanitizeFloat(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    float64
+		expected float64
+	}{
+		{name: "normal", input: 12.5, expected: 12.5},
+		{name: "nan", input: math.NaN(), expected: 0},
+		{name: "inf", input: math.Inf(1), expected: 0},
+		{name: "neg_inf", input: math.Inf(-1), expected: 0},
+		{name: "small", input: 1e-9, expected: 1e-9},
+		{name: "large", input: 9e15, expected: 9e15},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := sanitizeFloat(test.input)
+			if math.IsNaN(test.input) || math.IsInf(test.input, 0) {
+				if actual != 0 {
+					t.Fatalf("expected 0, got %v", actual)
+				}
+				return
+			}
+			if actual != test.expected {
+				t.Fatalf("expected %v, got %v", test.expected, actual)
+			}
+		})
+	}
+}

--- a/api_balancing/internal/control/playback_test.go
+++ b/api_balancing/internal/control/playback_test.go
@@ -1,0 +1,250 @@
+package control
+
+import (
+	"math"
+	"testing"
+)
+
+func TestExtractPublicHostFromOutputs(t *testing.T) {
+	tests := []struct {
+		name     string
+		outputs  map[string]interface{}
+		expected string
+	}{
+		{
+			name: "hls_protocol_relative",
+			outputs: map[string]interface{}{
+				"HLS": "//localhost:18090/view/stream/index.m3u8",
+			},
+			expected: "localhost:18090",
+		},
+		{
+			name: "http_array",
+			outputs: map[string]interface{}{
+				"HTTP": []interface{}{"http://media.example.com:8080/live/stream/index.m3u8"},
+			},
+			expected: "media.example.com:8080",
+		},
+		{
+			name: "no_matches",
+			outputs: map[string]interface{}{
+				"WHEP": "https://example.com/webrtc/stream",
+			},
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := ExtractPublicHostFromOutputs(test.outputs)
+			if actual != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestBuildOutputsMap(t *testing.T) {
+	rawOutputs := map[string]interface{}{
+		"HLS":  "//public.example.com:18090/view/$/index.m3u8",
+		"HTTP": "http://public.example.com:8080/live/$/index.m3u8",
+		"RTMP": "rtmp://HOST:1935/live/$",
+	}
+
+	outputs := BuildOutputsMap("https://edge.example.com/live", rawOutputs, "stream", false)
+
+	if outputs["MIST_HTML"].Url != "https://edge.example.com/live/stream.html" {
+		t.Fatalf("unexpected MIST_HTML url: %q", outputs["MIST_HTML"].Url)
+	}
+	if outputs["PLAYER_JS"].Url != "https://edge.example.com/live/player.js" {
+		t.Fatalf("unexpected PLAYER_JS url: %q", outputs["PLAYER_JS"].Url)
+	}
+	if outputs["WHEP"].Url != "https://edge.example.com/live/webrtc/stream" {
+		t.Fatalf("unexpected WHEP url: %q", outputs["WHEP"].Url)
+	}
+	if outputs["HLS"].Url != "//public.example.com:18090/view/stream/index.m3u8" {
+		t.Fatalf("unexpected HLS url: %q", outputs["HLS"].Url)
+	}
+	if outputs["RTMP"].Url != "rtmp://edge.example.com/live:1935/live/stream" {
+		t.Fatalf("unexpected RTMP url: %q", outputs["RTMP"].Url)
+	}
+}
+
+func TestBuildOutputCapabilities(t *testing.T) {
+	tests := []struct {
+		name             string
+		protocol         string
+		isLive           bool
+		expectedSeek     bool
+		expectedQuality  bool
+		expectedHasAudio bool
+		expectedHasVideo bool
+	}{
+		{
+			name:             "live_default",
+			protocol:         "HLS",
+			isLive:           true,
+			expectedSeek:     false,
+			expectedQuality:  true,
+			expectedHasAudio: true,
+			expectedHasVideo: true,
+		},
+		{
+			name:             "vod_mp4",
+			protocol:         "MP4",
+			isLive:           false,
+			expectedSeek:     true,
+			expectedQuality:  false,
+			expectedHasAudio: true,
+			expectedHasVideo: true,
+		},
+		{
+			name:             "whep_live",
+			protocol:         "WHEP",
+			isLive:           true,
+			expectedSeek:     false,
+			expectedQuality:  false,
+			expectedHasAudio: true,
+			expectedHasVideo: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			caps := BuildOutputCapabilities(test.protocol, test.isLive)
+			if caps.SupportsSeek != test.expectedSeek {
+				t.Fatalf("expected SupportsSeek=%v got %v", test.expectedSeek, caps.SupportsSeek)
+			}
+			if caps.SupportsQualitySwitch != test.expectedQuality {
+				t.Fatalf("expected SupportsQualitySwitch=%v got %v", test.expectedQuality, caps.SupportsQualitySwitch)
+			}
+			if caps.HasAudio != test.expectedHasAudio {
+				t.Fatalf("expected HasAudio=%v got %v", test.expectedHasAudio, caps.HasAudio)
+			}
+			if caps.HasVideo != test.expectedHasVideo {
+				t.Fatalf("expected HasVideo=%v got %v", test.expectedHasVideo, caps.HasVideo)
+			}
+		})
+	}
+}
+
+func TestDeriveWHEPFromHTML(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "valid_html",
+			input:    "https://example.com/live/stream.html",
+			expected: "https://example.com/live/webrtc/stream",
+		},
+		{
+			name:     "not_html",
+			input:    "https://example.com/live/stream.m3u8",
+			expected: "",
+		},
+		{
+			name:     "invalid_url",
+			input:    ":://bad-url",
+			expected: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := DeriveWHEPFromHTML(test.input)
+			if actual != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestCalculateGeoDistance(t *testing.T) {
+	tests := []struct {
+		name     string
+		lat1     float64
+		lon1     float64
+		lat2     float64
+		lon2     float64
+		expected float64
+		maxDelta float64
+	}{
+		{
+			name:     "same_point",
+			lat1:     0,
+			lon1:     0,
+			lat2:     0,
+			lon2:     0,
+			expected: 0,
+			maxDelta: 0.0001,
+		},
+		{
+			name:     "one_degree_equator",
+			lat1:     0,
+			lon1:     0,
+			lat2:     0,
+			lon2:     1,
+			expected: 111.195,
+			maxDelta: 0.1,
+		},
+		{
+			name:     "half_earth",
+			lat1:     0,
+			lon1:     0,
+			lat2:     0,
+			lon2:     180,
+			expected: 20015.086,
+			maxDelta: 0.5,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := CalculateGeoDistance(test.lat1, test.lon1, test.lat2, test.lon2)
+			delta := math.Abs(actual - test.expected)
+			if delta > test.maxDelta {
+				t.Fatalf("expected %v +/- %v, got %v", test.expected, test.maxDelta, actual)
+			}
+		})
+	}
+}
+
+func TestDeriveMistHTTPBase(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "default_port_from_4242",
+			input:    "https://example.com:4242",
+			expected: "https://example.com:8080",
+		},
+		{
+			name:     "preserve_custom_port",
+			input:    "http://example.com:3000",
+			expected: "http://example.com:3000",
+		},
+		{
+			name:     "no_scheme",
+			input:    "example.com",
+			expected: "http://example.com:8080",
+		},
+		{
+			name:     "no_scheme_with_port",
+			input:    "example.com:9090",
+			expected: "http://example.com:8080",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := DeriveMistHTTPBase(test.input)
+			if actual != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}

--- a/api_balancing/internal/storage/s3_client_test.go
+++ b/api_balancing/internal/storage/s3_client_test.go
@@ -1,0 +1,158 @@
+package storage
+
+import "testing"
+
+func TestBuildS3URL(t *testing.T) {
+	tests := []struct {
+		name     string
+		bucket   string
+		prefix   string
+		key      string
+		expected string
+	}{
+		{
+			name:     "with_prefix",
+			bucket:   "media-bucket",
+			prefix:   "tenant-a",
+			key:      "clips/clip-1.mp4",
+			expected: "s3://media-bucket/tenant-a/clips/clip-1.mp4",
+		},
+		{
+			name:     "no_prefix",
+			bucket:   "media-bucket",
+			prefix:   "",
+			key:      "vod/asset.mp4",
+			expected: "s3://media-bucket/vod/asset.mp4",
+		},
+		{
+			name:     "trim_slashes",
+			bucket:   "media-bucket",
+			prefix:   "tenant-a/",
+			key:      "/dvr/segment",
+			expected: "s3://media-bucket/tenant-a/dvr/segment",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := &S3Client{config: S3Config{Bucket: test.bucket, Prefix: test.prefix}}
+			actual := client.BuildS3URL(test.key)
+			if actual != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestBuildClipAndDVRS3Keys(t *testing.T) {
+	tests := []struct {
+		name     string
+		fn       func(*S3Client) string
+		expected string
+	}{
+		{
+			name: "clip_key",
+			fn: func(c *S3Client) string {
+				return c.BuildClipS3Key("tenant", "stream", "cliphash", "mp4")
+			},
+			expected: "clips/tenant/stream/cliphash.mp4",
+		},
+		{
+			name: "dvr_key",
+			fn: func(c *S3Client) string {
+				return c.BuildDVRS3Key("tenant", "internal", "dvrhash")
+			},
+			expected: "dvr/tenant/internal/dvrhash",
+		},
+	}
+
+	client := &S3Client{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := test.fn(client)
+			if actual != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestBuildVodS3Key(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		expected string
+	}{
+		{
+			name:     "with_extension",
+			filename: "video.mov",
+			expected: "vod/tenant/hash/hash.mov",
+		},
+		{
+			name:     "no_extension",
+			filename: "video",
+			expected: "vod/tenant/hash/hash.mp4",
+		},
+		{
+			name:     "trailing_dot",
+			filename: "video.",
+			expected: "vod/tenant/hash/hash.mp4",
+		},
+	}
+
+	client := &S3Client{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := client.BuildVodS3Key("tenant", "hash", test.filename)
+			if actual != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestCalculatePartSize(t *testing.T) {
+	tests := []struct {
+		name          string
+		totalSize     int64
+		expectedSize  int64
+		expectedCount int
+	}{
+		{
+			name:          "zero_size",
+			totalSize:     0,
+			expectedSize:  DefaultPartSize,
+			expectedCount: 0,
+		},
+		{
+			name:          "single_part",
+			totalSize:     10 * 1024 * 1024,
+			expectedSize:  DefaultPartSize,
+			expectedCount: 1,
+		},
+		{
+			name:          "multiple_parts",
+			totalSize:     DefaultPartSize*2 + 1,
+			expectedSize:  DefaultPartSize,
+			expectedCount: 3,
+		},
+		{
+			name:          "too_many_parts",
+			totalSize:     DefaultPartSize*MaxPartCount + 1,
+			expectedSize:  21 * 1024 * 1024,
+			expectedCount: 9524,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			partSize, partCount := CalculatePartSize(test.totalSize)
+			if partSize != test.expectedSize {
+				t.Fatalf("expected partSize %d, got %d", test.expectedSize, partSize)
+			}
+			if partCount != test.expectedCount {
+				t.Fatalf("expected partCount %d, got %d", test.expectedCount, partCount)
+			}
+		})
+	}
+}

--- a/api_billing/go.mod
+++ b/api_billing/go.mod
@@ -25,6 +25,7 @@ replace frameworks/pkg => ../pkg
 require (
 	github.com/ClickHouse/ch-go v0.71.0 // indirect
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect

--- a/api_billing/go.sum
+++ b/api_billing/go.sum
@@ -2,6 +2,8 @@ github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoy
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
 github.com/ClickHouse/clickhouse-go/v2 v2.43.0 h1:fUR05TrF1GyvLDa/mAQjkx7KbgwdLRffs2n9O3WobtE=
 github.com/ClickHouse/clickhouse-go/v2 v2.43.0/go.mod h1:o6jf7JM/zveWC/PP277BLxjHy5KjnGX/jfljhM4s34g=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 h1:1zYrtlhrZ6/b6SAjLSfKzWtdgqK0U+HtH/VcBWh1BaU=
 github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6/go.mod h1:ioLG6R+5bUSO1oeGSDxOV3FADARuMoytZCSX6MEMQkI=
 github.com/VictorAvelar/mollie-api-go/v4 v4.13.0 h1:5eu9BPBq7+2Gle14VsT5915CM3beYFOA7BOO24Rdyaw=
@@ -147,6 +149,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=

--- a/api_billing/internal/handlers/hdwallet_test.go
+++ b/api_billing/internal/handlers/hdwallet_test.go
@@ -1,0 +1,166 @@
+package handlers
+
+import (
+	"database/sql"
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/btcsuite/btcd/btcutil/hdkeychain"
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	testXpub = "xpub6DZ3xpo1ixWwwNDQ7KFTamRVM46FQtgcDxsmAyeBpTHEo79E1n1LuWiZSMSRhqMQmrHaqJpek2TbtTzbAdNWJm9AhGdv7iJUpDjA6oJD84b"
+)
+
+func TestDeriveAddressFromXpub(t *testing.T) {
+	tests := []struct {
+		name      string
+		xpub      string
+		index     uint32
+		expected  string
+		wantError bool
+	}{
+		{
+			name:     "index_zero",
+			xpub:     testXpub,
+			index:    0,
+			expected: "0x022b971dff0c43305e691ded7a14367af19d6407",
+		},
+		{
+			name:     "index_one",
+			xpub:     testXpub,
+			index:    1,
+			expected: "0xbb7a182240010703dc81d6b1eff630ca02a169fd",
+		},
+		{
+			name:      "invalid_xpub",
+			xpub:      "not-a-key",
+			index:     0,
+			wantError: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			address, err := DeriveAddressFromXpub(test.xpub, test.index)
+			if test.wantError {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if address != test.expected {
+				t.Fatalf("expected %q, got %q", test.expected, address)
+			}
+		})
+	}
+}
+
+func TestDeriveAddressFromXpubRejectsXprv(t *testing.T) {
+	seed, err := hex.DecodeString("000102030405060708090a0b0c0d0e0f")
+	if err != nil {
+		t.Fatalf("failed to decode seed: %v", err)
+	}
+	master, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
+	if err != nil {
+		t.Fatalf("failed to create master key: %v", err)
+	}
+	purpose, _ := master.Derive(hdkeychain.HardenedKeyStart + 44)
+	coin, _ := purpose.Derive(hdkeychain.HardenedKeyStart + 60)
+	account, _ := coin.Derive(hdkeychain.HardenedKeyStart + 0)
+	change, _ := account.Derive(0)
+
+	if _, err := DeriveAddressFromXpub(change.String(), 0); err == nil {
+		t.Fatalf("expected error for xprv input")
+	}
+}
+
+func TestValidateXpub(t *testing.T) {
+	tests := []struct {
+		name       string
+		setupRow   func(*sqlmock.Sqlmock)
+		wantErrMsg string
+	}{
+		{
+			name: "missing_state",
+			setupRow: func(mock *sqlmock.Sqlmock) {
+				(*mock).ExpectQuery("SELECT xpub FROM purser.hd_wallet_state WHERE id = 1").
+					WillReturnError(sql.ErrNoRows)
+			},
+			wantErrMsg: "hd_wallet_state not initialized",
+		},
+		{
+			name: "invalid_xpub",
+			setupRow: func(mock *sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"xpub"}).AddRow("not-a-key")
+				(*mock).ExpectQuery("SELECT xpub FROM purser.hd_wallet_state WHERE id = 1").
+					WillReturnRows(rows)
+			},
+			wantErrMsg: "invalid xpub",
+		},
+		{
+			name: "xprv_in_db",
+			setupRow: func(mock *sqlmock.Sqlmock) {
+				seed, err := hex.DecodeString("000102030405060708090a0b0c0d0e0f")
+				if err != nil {
+					t.Fatalf("failed to decode seed: %v", err)
+				}
+				master, err := hdkeychain.NewMaster(seed, &chaincfg.MainNetParams)
+				if err != nil {
+					t.Fatalf("failed to create master key: %v", err)
+				}
+				rows := sqlmock.NewRows([]string{"xpub"}).AddRow(master.String())
+				(*mock).ExpectQuery("SELECT xpub FROM purser.hd_wallet_state WHERE id = 1").
+					WillReturnRows(rows)
+			},
+			wantErrMsg: "CRITICAL: stored key is xprv",
+		},
+		{
+			name: "valid_xpub",
+			setupRow: func(mock *sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"xpub"}).AddRow(testXpub)
+				(*mock).ExpectQuery("SELECT xpub FROM purser.hd_wallet_state WHERE id = 1").
+					WillReturnRows(rows)
+			},
+			wantErrMsg: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			db, mock, err := sqlmock.New()
+			if err != nil {
+				t.Fatalf("failed to create sqlmock: %v", err)
+			}
+			defer db.Close()
+
+			test.setupRow(&mock)
+
+			wallet := &HDWallet{db: db, logger: logrus.New()}
+			err = wallet.ValidateXpub()
+			if test.wantErrMsg == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", test.wantErrMsg)
+				}
+				if !strings.Contains(err.Error(), test.wantErrMsg) {
+					t.Fatalf("expected error containing %q, got %v", test.wantErrMsg, err)
+				}
+			}
+
+			if err := mock.ExpectationsWereMet(); err != nil {
+				t.Fatalf("unmet expectations: %v", err)
+			}
+		})
+	}
+}

--- a/api_control/go.mod
+++ b/api_control/go.mod
@@ -18,6 +18,7 @@ replace frameworks/pkg => ../pkg
 require (
 	github.com/ClickHouse/ch-go v0.71.0 // indirect
 	github.com/ClickHouse/clickhouse-go/v2 v2.43.0 // indirect
+	github.com/DATA-DOG/go-sqlmock v1.5.2 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect

--- a/api_control/go.sum
+++ b/api_control/go.sum
@@ -2,6 +2,8 @@ github.com/ClickHouse/ch-go v0.71.0 h1:bUdZ/EZj/LcVHsMqaRUP2holqygrPWQKeMjc6nZoy
 github.com/ClickHouse/ch-go v0.71.0/go.mod h1:NwbNc+7jaqfY58dmdDUbG4Jl22vThgx1cYjBw0vtgXw=
 github.com/ClickHouse/clickhouse-go/v2 v2.43.0 h1:fUR05TrF1GyvLDa/mAQjkx7KbgwdLRffs2n9O3WobtE=
 github.com/ClickHouse/clickhouse-go/v2 v2.43.0/go.mod h1:o6jf7JM/zveWC/PP277BLxjHy5KjnGX/jfljhM4s34g=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -71,6 +73,7 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/compress v1.18.3 h1:9PJRvfbmTabkOX8moIpXPbMMbYN60bWImDDU7L+/6zw=
 github.com/klauspost/compress v1.18.3/go.mod h1:R0h/fSBs8DE4ENlcrlib3PsXS61voFxhIs2DeRhCvJ4=

--- a/api_control/internal/grpc/server_validation_test.go
+++ b/api_control/internal/grpc/server_validation_test.go
@@ -1,0 +1,219 @@
+package grpc
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/sirupsen/logrus"
+
+	pb "frameworks/pkg/proto"
+)
+
+func TestValidateStreamKey(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name      string
+		req       *pb.ValidateStreamKeyRequest
+		setupMock func(sqlmock.Sqlmock)
+		assert    func(*testing.T, *pb.ValidateStreamKeyResponse, error)
+	}{
+		{
+			name: "empty_stream_key",
+			req:  &pb.ValidateStreamKeyRequest{StreamKey: ""},
+			assert: func(t *testing.T, resp *pb.ValidateStreamKeyResponse, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if resp.Valid {
+					t.Fatalf("expected invalid response")
+				}
+				if resp.Error != "stream_key required" {
+					t.Fatalf("unexpected error message: %q", resp.Error)
+				}
+			},
+		},
+		{
+			name: "invalid_stream_key",
+			req:  &pb.ValidateStreamKeyRequest{StreamKey: "bad-key"},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("FROM commodore.streams").WithArgs("bad-key").WillReturnError(sql.ErrNoRows)
+			},
+			assert: func(t *testing.T, resp *pb.ValidateStreamKeyResponse, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if resp.Valid {
+					t.Fatalf("expected invalid response")
+				}
+				if resp.Error != "Invalid stream key" {
+					t.Fatalf("unexpected error message: %q", resp.Error)
+				}
+			},
+		},
+		{
+			name: "inactive_user",
+			req:  &pb.ValidateStreamKeyRequest{StreamKey: "inactive-key"},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"id", "user_id", "tenant_id", "internal_name", "is_active", "is_recording_enabled"}).
+					AddRow("stream-id", "user-id", "tenant-id", "internal", false, true)
+				mock.ExpectQuery("FROM commodore.streams").WithArgs("inactive-key").WillReturnRows(rows)
+			},
+			assert: func(t *testing.T, resp *pb.ValidateStreamKeyResponse, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if resp.Valid {
+					t.Fatalf("expected invalid response")
+				}
+				if resp.Error != "User account is inactive" {
+					t.Fatalf("unexpected error message: %q", resp.Error)
+				}
+			},
+		},
+		{
+			name: "active_user",
+			req:  &pb.ValidateStreamKeyRequest{StreamKey: "good-key"},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"id", "user_id", "tenant_id", "internal_name", "is_active", "is_recording_enabled"}).
+					AddRow("stream-id", "user-id", "tenant-id", "internal", true, true)
+				mock.ExpectQuery("FROM commodore.streams").WithArgs("good-key").WillReturnRows(rows)
+			},
+			assert: func(t *testing.T, resp *pb.ValidateStreamKeyResponse, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !resp.Valid {
+					t.Fatalf("expected valid response")
+				}
+				if resp.BillingModel != "postpaid" {
+					t.Fatalf("unexpected billing model: %q", resp.BillingModel)
+				}
+				if resp.InternalName != "internal" {
+					t.Fatalf("unexpected internal name: %q", resp.InternalName)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var db *sql.DB
+			var mock sqlmock.Sqlmock
+			if test.setupMock != nil {
+				var err error
+				db, mock, err = sqlmock.New()
+				if err != nil {
+					t.Fatalf("failed to create sqlmock: %v", err)
+				}
+				defer db.Close()
+				test.setupMock(mock)
+			}
+
+			server := &CommodoreServer{db: db, logger: logrus.New()}
+			resp, err := server.ValidateStreamKey(ctx, test.req)
+			test.assert(t, resp, err)
+
+			if test.setupMock != nil {
+				if err := mock.ExpectationsWereMet(); err != nil {
+					t.Fatalf("unmet expectations: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateAPIToken(t *testing.T) {
+	ctx := context.Background()
+	tests := []struct {
+		name      string
+		req       *pb.ValidateAPITokenRequest
+		setupMock func(sqlmock.Sqlmock)
+		assert    func(*testing.T, *pb.ValidateAPITokenResponse, error)
+	}{
+		{
+			name: "empty_token",
+			req:  &pb.ValidateAPITokenRequest{Token: ""},
+			assert: func(t *testing.T, resp *pb.ValidateAPITokenResponse, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if resp.Valid {
+					t.Fatalf("expected invalid response")
+				}
+			},
+		},
+		{
+			name: "invalid_token",
+			req:  &pb.ValidateAPITokenRequest{Token: "bad-token"},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				mock.ExpectQuery("FROM commodore.api_tokens").WithArgs(hashToken("bad-token")).WillReturnError(sql.ErrNoRows)
+			},
+			assert: func(t *testing.T, resp *pb.ValidateAPITokenResponse, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if resp.Valid {
+					t.Fatalf("expected invalid response")
+				}
+			},
+		},
+		{
+			name: "valid_token",
+			req:  &pb.ValidateAPITokenRequest{Token: "good-token"},
+			setupMock: func(mock sqlmock.Sqlmock) {
+				rows := sqlmock.NewRows([]string{"id", "user_id", "tenant_id", "permissions"}).
+					AddRow("token-id", "user-id", "tenant-id", "{read,write}")
+				mock.ExpectQuery("FROM commodore.api_tokens").WithArgs(hashToken("good-token")).WillReturnRows(rows)
+				mock.ExpectExec("UPDATE commodore.api_tokens SET last_used_at").WithArgs("token-id").WillReturnResult(sqlmock.NewResult(1, 1))
+				userRows := sqlmock.NewRows([]string{"email", "role"}).AddRow("user@example.com", "admin")
+				mock.ExpectQuery("SELECT email, role FROM commodore.users").WithArgs("user-id").WillReturnRows(userRows)
+			},
+			assert: func(t *testing.T, resp *pb.ValidateAPITokenResponse, err error) {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if !resp.Valid {
+					t.Fatalf("expected valid response")
+				}
+				if resp.Email != "user@example.com" || resp.Role != "admin" {
+					t.Fatalf("unexpected user details: %q %q", resp.Email, resp.Role)
+				}
+				if resp.TenantId != "tenant-id" || resp.UserId != "user-id" {
+					t.Fatalf("unexpected ids: %q %q", resp.TenantId, resp.UserId)
+				}
+				if len(resp.Permissions) != 2 || strings.Join(resp.Permissions, ",") != strings.Join([]string{"read", "write"}, ",") {
+					t.Fatalf("unexpected permissions: %v", resp.Permissions)
+				}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var db *sql.DB
+			var mock sqlmock.Sqlmock
+			if test.setupMock != nil {
+				var err error
+				db, mock, err = sqlmock.New()
+				if err != nil {
+					t.Fatalf("failed to create sqlmock: %v", err)
+				}
+				defer db.Close()
+				test.setupMock(mock)
+			}
+
+			server := &CommodoreServer{db: db, logger: logrus.New()}
+			resp, err := server.ValidateAPIToken(ctx, test.req)
+			test.assert(t, resp, err)
+
+			if test.setupMock != nil {
+				if err := mock.ExpectationsWereMet(); err != nil {
+					t.Fatalf("unmet expectations: %v", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for pure helper functions used by playback URL builders, S3 key/url builders, HD wallet derivation, gRPC validation, and billing sanitization to catch regressions early. 
- Provide deterministic, table-driven tests for functions with no external runtime deps so CI can validate logic across edge cases. 
- Add lightweight test dependencies where needed to allow DB-backed logic to be exercised with mocks. 

### Description
- Added table-driven tests for playback and URL/helper functions in `api_balancing/internal/control/playback_test.go` covering `ExtractPublicHostFromOutputs`, `BuildOutputsMap`, `BuildOutputCapabilities`, `DeriveWHEPFromHTML`, `CalculateGeoDistance`, and `DeriveMistHTTPBase`. 
- Added S3 URL/key and multipart sizing tests in `api_balancing/internal/storage/s3_client_test.go` covering `BuildS3URL`, `BuildClipS3Key`, `BuildDVRS3Key`, `BuildVodS3Key`, and `CalculatePartSize`. 
- Added HD wallet derivation and xpub validation tests in `api_billing/internal/handlers/hdwallet_test.go` using `sqlmock` and BIP vectors to exercise `DeriveAddressFromXpub` and `ValidateXpub`. 
- Added gRPC validation tests in `api_control/internal/grpc/server_validation_test.go` using `sqlmock` to cover `ValidateStreamKey` and `ValidateAPIToken`, and added `sanitizeFloat` tests in `api_analytics_query/internal/handlers/billing_test.go`. 
- Updated `api_billing` and `api_control` module files to include the test-only dependency `github.com/DATA-DOG/go-sqlmock` (and corresponding `go.sum` entries). 

### Testing
- Ran `cd api_balancing && go test ./internal/control ./internal/storage` and received `ok` for both packages. 
- Ran `cd api_billing && go test ./internal/handlers` and received `ok` for the HD wallet tests backed by `sqlmock`. 
- Ran `cd api_control && go test ./internal/grpc` and received `ok` for the gRPC validation tests using `sqlmock`. 
- Ran `cd api_analytics_query && go test ./internal/handlers` and received `ok` for `sanitizeFloat`; running `make lint` failed due to a repository lint configuration issue (`golangci-lint` config: `output.formats` expected a map but got a slice), which is unrelated to the new tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983acd8fb4c8330906c985fb9cd9dac)