### PR TITLE
Add Skipper chat widget components (Svelte) with SSE mock streaming

### DIFF
--- a/website_application/src/lib/components/index.ts
+++ b/website_application/src/lib/components/index.ts
@@ -10,3 +10,4 @@ export { default as GraphQLExplorer } from "./GraphQLExplorer.svelte";
 // Re-export from subdirectories for convenience
 export * from "./cards";
 export * from "./health";
+export * from "./skipper";

--- a/website_application/src/lib/components/skipper/SkipperChat.svelte
+++ b/website_application/src/lib/components/skipper/SkipperChat.svelte
@@ -1,0 +1,274 @@
+<script lang="ts">
+  import { tick } from "svelte";
+  import { MessageCircle, XIcon } from "lucide-svelte";
+  import SkipperMessage, {
+    type SkipperChatMessage,
+    type SkipperConfidence,
+  } from "./SkipperMessage.svelte";
+  import SkipperInput from "./SkipperInput.svelte";
+
+  interface Props {
+    mock?: boolean;
+  }
+
+  let { mock = true }: Props = $props();
+
+  let isOpen = $state(false);
+  let isStreaming = $state(false);
+  let draft = $state("");
+  let messages = $state<SkipperChatMessage[]>([]);
+  let scrollRef = $state<HTMLDivElement | null>(null);
+
+  function createId() {
+    if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+      return crypto.randomUUID();
+    }
+    return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  }
+
+  function updateMessage(id: string, update: Partial<SkipperChatMessage>) {
+    messages = messages.map((message) => (message.id === id ? { ...message, ...update } : message));
+  }
+
+  async function scrollToBottom() {
+    await tick();
+    if (scrollRef) {
+      scrollRef.scrollTop = scrollRef.scrollHeight;
+    }
+  }
+
+  async function handleSend(content: string) {
+    if (isStreaming) return;
+    const userMessage: SkipperChatMessage = {
+      id: createId(),
+      role: "user",
+      content,
+    };
+    messages = [...messages, userMessage];
+    draft = "";
+
+    const assistantId = createId();
+    messages = [
+      ...messages,
+      {
+        id: assistantId,
+        role: "assistant",
+        content: "",
+        confidence: "best_guess",
+      },
+    ];
+
+    await scrollToBottom();
+
+    if (mock) {
+      await mockStreamResponse(assistantId, content);
+      return;
+    }
+
+    await streamResponse(assistantId, content);
+  }
+
+  async function mockStreamResponse(id: string, content: string) {
+    isStreaming = true;
+    const sample =
+      "Here is a quick summary based on your dashboard context. Viewers are trending up by 12% week-over-week, with the highest engagement spikes on Saturday evenings. Consider scheduling your next live session in that window for maximum reach.";
+    const tokens = sample.split(" ");
+
+    for (const token of tokens) {
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      updateMessage(id, {
+        content: `${messages.find((message) => message.id === id)?.content ?? ""}${token} `,
+      });
+      await scrollToBottom();
+    }
+
+    updateMessage(id, {
+      confidence: "sourced",
+      citations: [
+        { label: "Dashboard analytics snapshot", url: "https://example.com/dashboard" },
+        { label: "Stream performance report", url: "https://example.com/report" },
+      ],
+      externalLinks: [
+        { label: "Livepeer engagement benchmark", url: "https://example.com/benchmark" },
+      ],
+      details: [
+        {
+          title: "Tool call: analytics.summary",
+          payload: {
+            request: content,
+            window: "Last 7 days",
+            metrics: ["concurrent_viewers", "chat_activity", "retention"],
+          },
+        },
+        {
+          title: "Raw response",
+          payload: {
+            trending: "+12%",
+            peakWindow: "Saturday 7-9pm",
+            recommendation: "Schedule next session in peak window",
+          },
+        },
+      ],
+    });
+
+    isStreaming = false;
+  }
+
+  async function streamResponse(id: string, content: string) {
+    isStreaming = true;
+    updateMessage(id, { confidence: "best_guess" });
+
+    const response = await fetch("/api/skipper/chat", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "text/event-stream",
+      },
+      body: JSON.stringify({ message: content }),
+    });
+
+    if (!response.ok || !response.body) {
+      updateMessage(id, {
+        content: "Unable to reach Skipper right now. Please try again soon.",
+        confidence: "unknown",
+      });
+      isStreaming = false;
+      return;
+    }
+
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let isDone = false;
+
+    while (!isDone) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      let separatorIndex = buffer.indexOf("\n\n");
+      while (separatorIndex !== -1) {
+        const rawEvent = buffer.slice(0, separatorIndex);
+        buffer = buffer.slice(separatorIndex + 2);
+        const dataLines = rawEvent
+          .split("\n")
+          .filter((line) => line.startsWith("data:"))
+          .map((line) => line.replace(/^data:\s?/, ""));
+        const data = dataLines.join("\n").trim();
+
+        if (data === "[DONE]") {
+          isDone = true;
+          break;
+        }
+
+        if (data) {
+          const parsed = tryParseJson(data);
+          if (parsed && typeof parsed === "object") {
+            if (parsed.type === "token" && typeof parsed.content === "string") {
+              appendToken(id, parsed.content);
+            } else if (parsed.type === "meta") {
+              updateMessage(id, {
+                confidence: parsed.confidence as SkipperConfidence,
+                citations: parsed.citations,
+                externalLinks: parsed.externalLinks,
+                details: parsed.details,
+              });
+            } else if (parsed.type === "done") {
+              isDone = true;
+              break;
+            }
+          } else {
+            appendToken(id, data);
+          }
+        }
+
+        separatorIndex = buffer.indexOf("\n\n");
+      }
+
+      await scrollToBottom();
+    }
+
+    isStreaming = false;
+  }
+
+  function appendToken(id: string, token: string) {
+    const current = messages.find((message) => message.id === id)?.content ?? "";
+    updateMessage(id, { content: `${current}${token}` });
+  }
+
+  function tryParseJson(data: string) {
+    try {
+      return JSON.parse(data);
+    } catch {
+      return null;
+    }
+  }
+</script>
+
+<div class="fixed bottom-4 right-4 z-40 flex flex-col items-end gap-3">
+  {#if isOpen}
+    <div
+      class="flex h-[520px] w-[360px] flex-col overflow-hidden rounded-2xl border border-border bg-card shadow-2xl"
+    >
+      <div class="flex items-center justify-between border-b border-border bg-muted/30 px-4 py-3">
+        <div
+          class="flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.2em] text-muted-foreground"
+        >
+          <MessageCircle class="h-4 w-4 text-primary" />
+          Skipper
+        </div>
+        <button
+          class="rounded-md border border-border bg-background/80 p-1 text-muted-foreground transition hover:text-foreground"
+          onclick={() => {
+            isOpen = false;
+          }}
+          aria-label="Close Skipper chat"
+        >
+          <XIcon class="h-4 w-4" />
+        </button>
+      </div>
+
+      <div class="flex-1 space-y-4 overflow-y-auto bg-background px-4 py-4" bind:this={scrollRef}>
+        {#if messages.length === 0}
+          <div
+            class="rounded-xl border border-dashed border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground"
+          >
+            Ask Skipper about viewer trends, stream health, or recommended actions.
+          </div>
+        {:else}
+          {#each messages as message (message.id)}
+            <div class={message.role === "user" ? "flex justify-end" : "flex justify-start"}>
+              <div class="max-w-[85%]">
+                <SkipperMessage {message} />
+              </div>
+            </div>
+          {/each}
+        {/if}
+      </div>
+
+      <div class="border-t border-border bg-muted/20 px-4 py-3">
+        <SkipperInput bind:value={draft} disabled={isStreaming} onSend={handleSend} />
+        <div class="mt-2 text-[11px] text-muted-foreground">
+          {#if mock}
+            Demo mode · streaming mock data
+          {:else}
+            Streaming live analytics from Skipper
+          {/if}
+        </div>
+      </div>
+    </div>
+  {/if}
+
+  <button
+    class="flex h-12 w-12 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-[0_14px_30px_rgba(0,0,0,0.35)] transition hover:-translate-y-0.5 hover:shadow-[0_20px_38px_rgba(0,0,0,0.4)]"
+    onclick={() => {
+      isOpen = !isOpen;
+    }}
+    aria-label="Toggle Skipper chat"
+  >
+    {#if isOpen}
+      <XIcon class="h-5 w-5" />
+    {:else}
+      <MessageCircle class="h-5 w-5" />
+    {/if}
+  </button>
+</div>

--- a/website_application/src/lib/components/skipper/SkipperInput.svelte
+++ b/website_application/src/lib/components/skipper/SkipperInput.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+  interface Props {
+    value?: string;
+    disabled?: boolean;
+    placeholder?: string;
+    onSend?: (message: string) => void;
+  }
+
+  let {
+    value = $bindable(""),
+    disabled = false,
+    placeholder = "Ask Skipper anything about your dashboard...",
+    onSend = () => {},
+  }: Props = $props();
+
+  function handleSubmit(event: SubmitEvent) {
+    event.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    value = "";
+  }
+</script>
+
+<form class="flex items-end gap-2" onsubmit={handleSubmit}>
+  <div class="flex-1">
+    <textarea
+      bind:value
+      rows={2}
+      class="w-full resize-none rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 disabled:cursor-not-allowed disabled:opacity-60"
+      {placeholder}
+      {disabled}
+    ></textarea>
+  </div>
+  <button
+    type="submit"
+    class="h-9 shrink-0 rounded-lg bg-primary px-4 text-sm font-semibold text-primary-foreground shadow-sm transition disabled:cursor-not-allowed disabled:opacity-60"
+    disabled={disabled || !value.trim()}
+  >
+    Send
+  </button>
+</form>

--- a/website_application/src/lib/components/skipper/SkipperMessage.svelte
+++ b/website_application/src/lib/components/skipper/SkipperMessage.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  export type SkipperConfidence = "verified" | "sourced" | "best_guess" | "unknown";
+
+  export interface SkipperCitation {
+    label: string;
+    url: string;
+  }
+
+  export interface SkipperDetail {
+    title?: string;
+    payload: string | Record<string, unknown>;
+  }
+
+  export interface SkipperChatMessage {
+    id: string;
+    role: "user" | "assistant";
+    content: string;
+    confidence?: SkipperConfidence;
+    citations?: SkipperCitation[];
+    externalLinks?: SkipperCitation[];
+    details?: SkipperDetail[];
+  }
+
+  interface Props {
+    message: SkipperChatMessage;
+  }
+
+  let { message }: Props = $props();
+
+  const confidenceLabels: Record<SkipperConfidence, string> = {
+    verified: "Verified",
+    sourced: "Sourced",
+    best_guess: "Best guess",
+    unknown: "Unknown",
+  };
+
+  function escapeHtml(value: string) {
+    return value
+      .replaceAll("&", "&amp;")
+      .replaceAll("<", "&lt;")
+      .replaceAll(">", "&gt;")
+      .replaceAll('"', "&quot;")
+      .replaceAll("'", "&#039;");
+  }
+
+  function renderMarkdown(value: string) {
+    const blocks: string[] = [];
+    let working = value.replace(/```([\s\S]*?)```/g, (_match, code) => {
+      const index = blocks.length;
+      blocks.push(
+        `<pre class=\"mt-3 overflow-x-auto rounded-md border border-border bg-muted/40 p-3 text-xs text-foreground\"><code>${escapeHtml(
+          code.trim()
+        )}</code></pre>`
+      );
+      return `__BLOCK_${index}__`;
+    });
+
+    working = escapeHtml(working);
+    working = working.replace(
+      /`([^`]+)`/g,
+      '<code class="rounded bg-muted/60 px-1 py-0.5 text-xs">$1</code>'
+    );
+    working = working.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+    working = working.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+    working = working.replace(
+      /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g,
+      '<a class="text-primary underline underline-offset-4 hover:text-primary/80" href="$2" target="_blank" rel="noreferrer">$1</a>'
+    );
+    working = working.replace(/\n/g, "<br />");
+
+    blocks.forEach((block, index) => {
+      working = working.replace(`__BLOCK_${index}__`, block);
+    });
+
+    return working;
+  }
+
+  function formatDetail(detail: SkipperDetail) {
+    if (typeof detail.payload === "string") return detail.payload;
+    return JSON.stringify(detail.payload, null, 2);
+  }
+</script>
+
+<div class="flex flex-col gap-2">
+  <div class="flex items-center gap-2 text-xs uppercase tracking-[0.2em] text-muted-foreground">
+    <span class="font-semibold">{message.role === "assistant" ? "Skipper" : "You"}</span>
+    {#if message.role === "assistant" && message.confidence}
+      <span
+        class="rounded-full border border-border bg-muted/40 px-2 py-0.5 text-[10px] tracking-[0.16em]"
+      >
+        {confidenceLabels[message.confidence]}
+      </span>
+    {/if}
+    {#if message.role === "assistant" && message.confidence === "sourced"}
+      <span
+        class="rounded-full border border-primary/40 bg-primary/10 px-2 py-0.5 text-[10px] font-semibold text-primary"
+      >
+        External
+      </span>
+    {/if}
+  </div>
+
+  {#if message.role === "assistant" && message.confidence === "best_guess"}
+    <div class="rounded-md border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning">
+      Best guess — verify with primary data before acting.
+    </div>
+  {/if}
+
+  {#if message.role === "assistant" && message.confidence === "unknown"}
+    <div
+      class="rounded-md border border-muted-foreground/30 bg-muted/50 px-3 py-2 text-xs text-muted-foreground"
+    >
+      I could not validate a confident answer based on available data.
+    </div>
+  {/if}
+
+  <div
+    class={message.role === "assistant"
+      ? "rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground"
+      : "rounded-xl bg-primary px-4 py-3 text-sm text-primary-foreground"}
+  >
+    <div class={message.confidence === "best_guess" ? "opacity-80" : "opacity-100"}>
+      <div class="prose prose-sm max-w-none text-inherit prose-a:text-primary">
+        {@html renderMarkdown(message.content)}
+      </div>
+    </div>
+  </div>
+
+  {#if message.role === "assistant" && message.citations?.length}
+    <div
+      class="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+    >
+      <div class="font-semibold uppercase tracking-[0.16em] text-[10px]">Citations</div>
+      <ul class="mt-2 space-y-1">
+        {#each message.citations as citation}
+          <li>
+            <a
+              class="text-primary underline underline-offset-4"
+              href={citation.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {citation.label}
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+
+  {#if message.role === "assistant" && message.externalLinks?.length}
+    <div
+      class="rounded-md border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground"
+    >
+      <div class="font-semibold uppercase tracking-[0.16em] text-[10px]">External sources</div>
+      <ul class="mt-2 space-y-1">
+        {#each message.externalLinks as link}
+          <li>
+            <a
+              class="text-primary underline underline-offset-4"
+              href={link.url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {link.label}
+            </a>
+          </li>
+        {/each}
+      </ul>
+    </div>
+  {/if}
+
+  {#if message.role === "assistant" && message.details?.length}
+    <details
+      class="rounded-md border border-border bg-muted/40 px-3 py-2 text-xs text-muted-foreground"
+    >
+      <summary class="cursor-pointer font-semibold uppercase tracking-[0.16em] text-[10px]">
+        Details
+      </summary>
+      <div class="mt-2 space-y-2">
+        {#each message.details as detail}
+          <div>
+            {#if detail.title}
+              <div class="font-semibold text-foreground">{detail.title}</div>
+            {/if}
+            <pre
+              class="mt-1 whitespace-pre-wrap rounded-md border border-border bg-background/80 p-2 text-[11px] text-foreground">
+{formatDetail(detail)}
+            </pre>
+          </div>
+        {/each}
+      </div>
+    </details>
+  {/if}
+</div>

--- a/website_application/src/lib/components/skipper/index.ts
+++ b/website_application/src/lib/components/skipper/index.ts
@@ -1,0 +1,3 @@
+export { default as SkipperChat } from "./SkipperChat.svelte";
+export { default as SkipperInput } from "./SkipperInput.svelte";
+export { default as SkipperMessage } from "./SkipperMessage.svelte";


### PR DESCRIPTION
### Motivation

- Provide a dashboard-integrated Skipper chat widget that surfaces analytics summaries and tool outputs with confidence-aware UI and no extra dependencies.
- Ship a first-stage client that supports SSE streaming parsing and a mock-response mode while the real `/api/skipper/chat` endpoint is delivered in a later batch.

### Description

- Added a floating chat container component that expands to a panel and renders streaming assistant responses: `website_application/src/lib/components/skipper/SkipperChat.svelte`.
- Implemented message bubble rendering with markdown, confidence labels, citations, external links, warning/info banners, and a collapsible Details section: `website_application/src/lib/components/skipper/SkipperMessage.svelte`.
- Implemented the message input with send button disabled while streaming: `website_application/src/lib/components/skipper/SkipperInput.svelte`.
- Wire-up and SSE parsing: chat supports token-by-token streaming append, `meta` messages to set confidence/citations/details, a `[DONE]` sentinel, and a `mockStreamResponse` helper for demo mode; scrolling uses `tick()` to stay pinned to bottom.
- Exported the new components and re-exported them from the shared index: `website_application/src/lib/components/skipper/index.ts` and `website_application/src/lib/components/index.ts`.

### Testing

- Pre-commit hooks were executed as part of committing changes and ran `frontend-lint` and `frontend-format` automated checks via Lefthook; `frontend-format` completed with a Node engine warning and formatting ran, and `frontend-lint` reported an ESLint configuration issue causing a lint failure to be reported by the hook. (Status: format run OK with warnings; lint reported config missing.)
- No unit or integration tests were added for the UI in this change; local frontend test command to run is `cd website_application && pnpm test` and repo-wide verification is `make verify` (not run in CI here).
- Suggested make/npm targets to run locally: `make lint`, `make lint-fix`, `cd website_application && pnpm lint`, and `cd website_application && pnpm format` to match repository standards.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852caa07588330b8f95217b02f41e0)