### PR TITLE
api_skipper: add search_web tool wrapper and confidence helpers

### DIFF
--- a/api_skipper/internal/chat/confidence.go
+++ b/api_skipper/internal/chat/confidence.go
@@ -1,0 +1,44 @@
+package chat
+
+type Confidence string
+
+const (
+	ConfidenceVerified  Confidence = "verified"
+	ConfidenceSourced   Confidence = "sourced"
+	ConfidenceBestGuess Confidence = "best_guess"
+	ConfidenceUnknown   Confidence = "unknown"
+)
+
+type SourceType string
+
+const (
+	SourceTypeKnowledgeBase SourceType = "knowledge_base"
+	SourceTypeWeb           SourceType = "web"
+	SourceTypeLLM           SourceType = "llm"
+	SourceTypeUnknown       SourceType = "unknown"
+)
+
+type Source struct {
+	Title string     `json:"title"`
+	URL   string     `json:"url"`
+	Type  SourceType `json:"type"`
+}
+
+type ConfidenceBlock struct {
+	Content    string     `json:"content"`
+	Confidence Confidence `json:"confidence"`
+	Sources    []Source   `json:"sources,omitempty"`
+}
+
+func ConfidenceFromSourceType(sourceType SourceType) Confidence {
+	switch sourceType {
+	case SourceTypeKnowledgeBase:
+		return ConfidenceVerified
+	case SourceTypeWeb:
+		return ConfidenceSourced
+	case SourceTypeLLM:
+		return ConfidenceBestGuess
+	default:
+		return ConfidenceUnknown
+	}
+}

--- a/api_skipper/internal/chat/search_web.go
+++ b/api_skipper/internal/chat/search_web.go
@@ -1,0 +1,158 @@
+package chat
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"frameworks/pkg/search"
+)
+
+const (
+	defaultSearchLimit  = 5
+	defaultSearchDepth  = "basic"
+	maxSnippetRuneCount = 320
+)
+
+type SearchWebInput struct {
+	Query       string `json:"query"`
+	Limit       int    `json:"limit,omitempty"`
+	SearchDepth string `json:"search_depth,omitempty"`
+}
+
+type SearchWebResult struct {
+	Title   string  `json:"title"`
+	URL     string  `json:"url"`
+	Snippet string  `json:"snippet,omitempty"`
+	Score   float64 `json:"score,omitempty"`
+}
+
+type SearchWebResponse struct {
+	Query   string            `json:"query"`
+	Context string            `json:"context"`
+	Results []SearchWebResult `json:"results"`
+	Sources []Source          `json:"sources"`
+}
+
+type SearchWebTool struct {
+	provider search.Provider
+}
+
+func NewSearchWebTool(provider search.Provider) *SearchWebTool {
+	return &SearchWebTool{provider: provider}
+}
+
+func (t *SearchWebTool) Call(ctx context.Context, arguments string) (SearchWebResponse, error) {
+	if t.provider == nil {
+		return SearchWebResponse{}, errors.New("search provider is required")
+	}
+
+	var input SearchWebInput
+	if err := json.Unmarshal([]byte(arguments), &input); err != nil {
+		return SearchWebResponse{}, fmt.Errorf("parse search_web arguments: %w", err)
+	}
+
+	return t.Search(ctx, input)
+}
+
+func (t *SearchWebTool) Search(ctx context.Context, input SearchWebInput) (SearchWebResponse, error) {
+	query := strings.TrimSpace(input.Query)
+	if query == "" {
+		return SearchWebResponse{}, errors.New("search query is required")
+	}
+
+	limit := input.Limit
+	if limit <= 0 {
+		limit = defaultSearchLimit
+	}
+
+	depth := strings.TrimSpace(input.SearchDepth)
+	if depth == "" {
+		depth = defaultSearchDepth
+	}
+
+	results, err := t.provider.Search(ctx, query, search.SearchOptions{
+		Limit:       limit,
+		SearchDepth: depth,
+	})
+	if err != nil {
+		return SearchWebResponse{}, err
+	}
+
+	mapped := make([]SearchWebResult, 0, len(results))
+	sources := make([]Source, 0, len(results))
+	for _, result := range results {
+		title := strings.TrimSpace(result.Title)
+		url := strings.TrimSpace(result.URL)
+		if title == "" {
+			title = url
+		}
+		snippet := snippetFromContent(result.Content)
+		mapped = append(mapped, SearchWebResult{
+			Title:   title,
+			URL:     url,
+			Snippet: snippet,
+			Score:   result.Score,
+		})
+		sources = append(sources, Source{
+			Title: title,
+			URL:   url,
+			Type:  SourceTypeWeb,
+		})
+	}
+
+	return SearchWebResponse{
+		Query:   query,
+		Context: formatSearchContext(mapped),
+		Results: mapped,
+		Sources: sources,
+	}, nil
+}
+
+func formatSearchContext(results []SearchWebResult) string {
+	if len(results) == 0 {
+		return "No web search results found."
+	}
+
+	var builder strings.Builder
+	builder.WriteString("Web search results:\n")
+	for i, result := range results {
+		fmt.Fprintf(&builder, "%d. %s\n", i+1, result.Title)
+		if result.URL != "" {
+			fmt.Fprintf(&builder, "URL: %s\n", result.URL)
+		}
+		if result.Snippet != "" {
+			fmt.Fprintf(&builder, "Snippet: %s\n", result.Snippet)
+		}
+		if i < len(results)-1 {
+			builder.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSpace(builder.String())
+}
+
+func snippetFromContent(content string) string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return ""
+	}
+	content = strings.Join(strings.Fields(content), " ")
+	return truncateRunes(content, maxSnippetRuneCount)
+}
+
+func truncateRunes(input string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(input)
+	if len(runes) <= limit {
+		return input
+	}
+	if limit == 1 {
+		return string(runes[:1])
+	}
+	return string(runes[:limit-1]) + "…"
+}


### PR DESCRIPTION
### Motivation
- Add web-search grounding for Skipper so the LLM can fall back to live web results when the RAG KB is insufficient. 
- Provide a small, frontend-compatible confidence model so responses can be tagged and styled by trust level.

### Description
- Implemented confidence types, `Source`, and `ConfidenceBlock` with `ConfidenceFromSourceType` helper at `api_skipper/internal/chat/confidence.go`.
- Added a thin `search_web` tool wrapper at `api_skipper/internal/chat/search_web.go` that parses JSON tool arguments, calls `frameworks/pkg/search` provider `Search`, maps `pkg/search.Result` → structured `SearchWebResult`, extracts a trimmed snippet, and builds `Context` text suitable for LLM tool responses.
- Exposed `NewSearchWebTool`, `Call`, and `Search` methods and small helpers `formatSearchContext`, `snippetFromContent`, and `truncateRunes` to shape LLM-facing output and sources.
- Change set modifies/creates: `api_skipper/internal/chat/confidence.go` and `api_skipper/internal/chat/search_web.go` and depends on the existing `pkg/search` provider interface.

### Testing
- Ran `make lint` which completed and reported `0 issues` for the repository lint pass.
- Pre-commit hooks ran during the commit (lefthook) with non-fatal linter warnings noted but the changes were committed successfully.

Recommended Makefile targets to validate locally: `make lint`, `make build-bin-api_skipper`, `make test`, and `make verify`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852ca95280833094cf199b4e3bc67a)