### PR TITLE
api_dns: add ACME issuance/renewal tests and make ACME/DNS/worker deps injectable

### DIFF
--- a/api_dns/go.mod
+++ b/api_dns/go.mod
@@ -8,6 +8,7 @@ require (
 	frameworks/pkg v0.0.0
 	github.com/failsafe-go/failsafe-go v0.9.5
 	github.com/gin-gonic/gin v1.11.0
+	github.com/stretchr/testify v1.11.1
 	google.golang.org/grpc v1.78.0
 )
 
@@ -19,6 +20,7 @@ require (
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/go-faster/city v1.0.1 // indirect
 	github.com/go-faster/errors v0.7.1 // indirect
@@ -27,6 +29,7 @@ require (
 	github.com/lib/pq v1.11.1 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/paulmach/orb v0.12.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/quic-go/quic-go v0.57.0 // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
@@ -35,6 +38,7 @@ require (
 	go.opentelemetry.io/otel/trace v1.39.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
 
 require (

--- a/api_dns/internal/logic/cert_test.go
+++ b/api_dns/internal/logic/cert_test.go
@@ -1,0 +1,221 @@
+package logic
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"testing"
+	"time"
+
+	"frameworks/api_dns/internal/store"
+
+	"github.com/go-acme/lego/v4/certificate"
+	"github.com/go-acme/lego/v4/challenge"
+	"github.com/go-acme/lego/v4/lego"
+	"github.com/go-acme/lego/v4/registration"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeStore struct {
+	getCertFunc       func(ctx context.Context, tenantID, domain string) (*store.Certificate, error)
+	saveCertFunc      func(ctx context.Context, tenantID string, cert *store.Certificate) error
+	getAccountFunc    func(ctx context.Context, tenantID, email string) (*store.ACMEAccount, error)
+	saveAccountFunc   func(ctx context.Context, tenantID string, acc *store.ACMEAccount) error
+	saveCertCalled    int
+	saveAccountCalled int
+}
+
+func (f *fakeStore) GetCertificate(ctx context.Context, tenantID, domain string) (*store.Certificate, error) {
+	return f.getCertFunc(ctx, tenantID, domain)
+}
+
+func (f *fakeStore) SaveCertificate(ctx context.Context, tenantID string, cert *store.Certificate) error {
+	f.saveCertCalled++
+	return f.saveCertFunc(ctx, tenantID, cert)
+}
+
+func (f *fakeStore) GetACMEAccount(ctx context.Context, tenantID, email string) (*store.ACMEAccount, error) {
+	return f.getAccountFunc(ctx, tenantID, email)
+}
+
+func (f *fakeStore) SaveACMEAccount(ctx context.Context, tenantID string, acc *store.ACMEAccount) error {
+	f.saveAccountCalled++
+	return f.saveAccountFunc(ctx, tenantID, acc)
+}
+
+type fakeDNSProvider struct {
+	presentCalls int
+	cleanupCalls int
+	presentErr   error
+	cleanupErr   error
+}
+
+func (f *fakeDNSProvider) Present(domain, token, keyAuth string) error {
+	f.presentCalls++
+	return f.presentErr
+}
+
+func (f *fakeDNSProvider) CleanUp(domain, token, keyAuth string) error {
+	f.cleanupCalls++
+	return f.cleanupErr
+}
+
+type fakeACMEClient struct {
+	provider       challenge.Provider
+	registerCalled int
+	obtainCalled   int
+	registerErr    error
+	obtainErr      error
+	resource       *certificate.Resource
+}
+
+func (f *fakeACMEClient) SetDNS01Provider(provider challenge.Provider) error {
+	f.provider = provider
+	return nil
+}
+
+func (f *fakeACMEClient) Register() (*registration.Resource, error) {
+	f.registerCalled++
+	if f.registerErr != nil {
+		return nil, f.registerErr
+	}
+	return &registration.Resource{URI: "acct-1"}, nil
+}
+
+func (f *fakeACMEClient) Obtain(request certificate.ObtainRequest) (*certificate.Resource, error) {
+	f.obtainCalled++
+	if f.provider != nil {
+		if err := f.provider.Present(request.Domains[0], "token", "keyAuth"); err != nil {
+			return nil, err
+		}
+	}
+
+	if f.obtainErr != nil {
+		if f.provider != nil {
+			_ = f.provider.CleanUp(request.Domains[0], "token", "keyAuth")
+		}
+		return nil, f.obtainErr
+	}
+
+	if f.provider != nil {
+		_ = f.provider.CleanUp(request.Domains[0], "token", "keyAuth")
+	}
+
+	return f.resource, nil
+}
+
+func TestIssueCertificateSetsUpAndCleansUpChallenges(t *testing.T) {
+	ctx := context.Background()
+	notAfter := time.Now().Add(10 * time.Hour)
+	certPEM, keyPEM := buildTestCert(t, notAfter)
+
+	provider := &fakeDNSProvider{}
+	acme := &fakeACMEClient{
+		resource: &certificate.Resource{
+			Certificate: certPEM,
+			PrivateKey:  keyPEM,
+		},
+	}
+	fakeStore := &fakeStore{
+		getCertFunc: func(ctx context.Context, tenantID, domain string) (*store.Certificate, error) {
+			return nil, store.ErrNotFound
+		},
+		saveCertFunc: func(ctx context.Context, tenantID string, cert *store.Certificate) error {
+			return nil
+		},
+		getAccountFunc: func(ctx context.Context, tenantID, email string) (*store.ACMEAccount, error) {
+			return nil, store.ErrNotFound
+		},
+		saveAccountFunc: func(ctx context.Context, tenantID string, acc *store.ACMEAccount) error {
+			return nil
+		},
+	}
+
+	manager := NewCertManager(fakeStore)
+	manager.acmeClientFactory = func(config *lego.Config) (acmeClient, error) {
+		return acme, nil
+	}
+	manager.dnsProviderFactory = func() (challenge.Provider, error) {
+		return provider, nil
+	}
+
+	returnedCert, returnedKey, expiresAt, err := manager.IssueCertificate(ctx, "", "example.com", "me@example.com")
+	require.NoError(t, err)
+	require.Equal(t, string(certPEM), returnedCert)
+	require.Equal(t, string(keyPEM), returnedKey)
+	require.WithinDuration(t, notAfter, expiresAt, time.Second)
+	require.Equal(t, 1, provider.presentCalls)
+	require.Equal(t, 1, provider.cleanupCalls)
+	require.Equal(t, 1, acme.registerCalled)
+	require.Equal(t, 1, acme.obtainCalled)
+	require.Equal(t, 1, fakeStore.saveAccountCalled)
+	require.Equal(t, 1, fakeStore.saveCertCalled)
+}
+
+func TestIssueCertificateFailureDoesNotPersistCertificate(t *testing.T) {
+	ctx := context.Background()
+	provider := &fakeDNSProvider{}
+	acme := &fakeACMEClient{
+		obtainErr: errors.New("acme boom"),
+	}
+	fakeStore := &fakeStore{
+		getCertFunc: func(ctx context.Context, tenantID, domain string) (*store.Certificate, error) {
+			return nil, store.ErrNotFound
+		},
+		saveCertFunc: func(ctx context.Context, tenantID string, cert *store.Certificate) error {
+			return nil
+		},
+		getAccountFunc: func(ctx context.Context, tenantID, email string) (*store.ACMEAccount, error) {
+			return nil, store.ErrNotFound
+		},
+		saveAccountFunc: func(ctx context.Context, tenantID string, acc *store.ACMEAccount) error {
+			return nil
+		},
+	}
+
+	manager := NewCertManager(fakeStore)
+	manager.acmeClientFactory = func(config *lego.Config) (acmeClient, error) {
+		return acme, nil
+	}
+	manager.dnsProviderFactory = func() (challenge.Provider, error) {
+		return provider, nil
+	}
+
+	_, _, _, err := manager.IssueCertificate(ctx, "", "example.com", "me@example.com")
+	require.Error(t, err)
+	require.Equal(t, 1, provider.presentCalls)
+	require.Equal(t, 1, provider.cleanupCalls)
+	require.Equal(t, 0, fakeStore.saveCertCalled)
+}
+
+func buildTestCert(t *testing.T, notAfter time.Time) ([]byte, []byte) {
+	t.Helper()
+
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	serial, err := rand.Int(rand.Reader, big.NewInt(1<<62))
+	require.NoError(t, err)
+
+	template := x509.Certificate{
+		SerialNumber: serial,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     notAfter,
+		DNSNames:     []string{"example.com"},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &privateKey.PublicKey, privateKey)
+	require.NoError(t, err)
+
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyBytes, err := x509.MarshalECPrivateKey(privateKey)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyBytes})
+
+	return certPEM, keyPEM
+}

--- a/api_dns/internal/worker/renewal_test.go
+++ b/api_dns/internal/worker/renewal_test.go
@@ -1,0 +1,92 @@
+package worker
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+	"time"
+
+	"frameworks/api_dns/internal/store"
+	"frameworks/pkg/logging"
+
+	"github.com/stretchr/testify/require"
+)
+
+type fakeRenewStore struct {
+	certs []store.Certificate
+	err   error
+}
+
+func (f *fakeRenewStore) ListExpiringCertificates(ctx context.Context, threshold time.Duration) ([]store.Certificate, error) {
+	return f.certs, f.err
+}
+
+type fakeIssuer struct {
+	results []error
+	calls   []string
+}
+
+func (f *fakeIssuer) IssueCertificate(ctx context.Context, tenantID, domain, email string) (string, string, time.Time, error) {
+	f.calls = append(f.calls, domain)
+	if len(f.results) == 0 {
+		return "", "", time.Time{}, nil
+	}
+	err := f.results[0]
+	f.results = f.results[1:]
+	return "", "", time.Time{}, err
+}
+
+func TestRenewalWorkerRetriesWithBackoff(t *testing.T) {
+	retryErr := errors.New("rate limit: 429")
+	store := &fakeRenewStore{
+		certs: []store.Certificate{
+			{Domain: "example.com", TenantID: sql.NullString{Valid: false}},
+		},
+	}
+	issuer := &fakeIssuer{
+		results: []error{retryErr, retryErr, nil},
+	}
+	var sleeps []time.Duration
+
+	worker := &RenewalWorker{
+		store:       store,
+		certManager: issuer,
+		logger:      logging.NewLogger(),
+		sleep: func(ctx context.Context, duration time.Duration) error {
+			sleeps = append(sleeps, duration)
+			return nil
+		},
+	}
+
+	worker.renewCertificates(context.Background())
+
+	require.Equal(t, []string{"example.com", "example.com", "example.com"}, issuer.calls)
+	require.Equal(t, []time.Duration{30 * time.Second, 60 * time.Second}, sleeps)
+}
+
+func TestRenewalWorkerSkipsRetriesOnNonRetryableErrorAndContinues(t *testing.T) {
+	nonRetryErr := errors.New("invalid response")
+	store := &fakeRenewStore{
+		certs: []store.Certificate{
+			{Domain: "fail.example.com", TenantID: sql.NullString{Valid: false}},
+			{Domain: "next.example.com", TenantID: sql.NullString{Valid: false}},
+		},
+	}
+	issuer := &fakeIssuer{
+		results: []error{nonRetryErr, nil},
+	}
+
+	worker := &RenewalWorker{
+		store:       store,
+		certManager: issuer,
+		logger:      logging.NewLogger(),
+		sleep: func(ctx context.Context, duration time.Duration) error {
+			return nil
+		},
+	}
+
+	worker.renewCertificates(context.Background())
+
+	require.Equal(t, []string{"fail.example.com", "next.example.com"}, issuer.calls)
+}


### PR DESCRIPTION
### Motivation

- Improve coverage for ACME certificate issuance and renewal failure modes (challenge setup/cleanup, retry/backoff, partial-failure rollback). 
- Make ACME and DNS provider usage testable without touching generated or production-only code. 
- Make renewal worker behavior deterministic in tests (injectable sleep/backoff and store/issuer interfaces).

### Description

- Refactor `CertManager` to accept testable abstractions: convert internal store usage to a `certStore` interface and add injectable `acmeClientFactory` and `dnsProviderFactory` hooks; keep production defaults that call `lego.NewClient` and `cloudflare.NewDNSProvider` (file: `api_dns/internal/logic/cert.go`).
- Add a minimal `legoClient` wrapper implementing the `acmeClient` interface so production lego client behavior is preserved while allowing fakes in tests.
- Update issuance code to call through the new interfaces (`SetDNS01Provider`, `Register`, `Obtain`) so challenges can be observed/controlled by tests.
- Make `RenewalWorker` testable by introducing `renewalStore`, `certIssuer` and `sleepFunc` abstractions and a `defaultSleep` implementation; wire defaults in the constructor (file: `api_dns/internal/worker/renewal.go`).
- Add unit tests that simulate ACME flows and renewals: `api_dns/internal/logic/cert_test.go` covers challenge `Present`/`CleanUp`, account save, and verifies no certificate persistence on ACME obtain failures; `api_dns/internal/worker/renewal_test.go` covers retry/backoff behavior and skipping retries for non-retryable errors.
- Add `github.com/stretchr/testify` to `api_dns/go.mod` for test assertions and run `go mod tidy`.

### Testing

- Ran `gofmt` and `go mod tidy` to keep module tidy and formatting consistent; both completed successfully. 
- Executed focused unit tests with `go test ./internal/logic ./internal/worker -count=1` and they passed (`ok` for both packages). 
- An initial `go test ./...` for the whole module stalled during a broader run and was terminated; focused package tests were used instead to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698882cb7de48330a78e0a35881592ee)