### PR TITLE
tests(api_consultant): add MCP reconnect, docs-mode tool guard, and usage/billing tests

### DIFF
--- a/api_consultant/internal/skipper/decklog_adapter_test.go
+++ b/api_consultant/internal/skipper/decklog_adapter_test.go
@@ -69,3 +69,41 @@ func TestDecklogUsageLoggerPopulatesCorrelationFields(t *testing.T) {
 		t.Fatalf("expected user_hash %d, got %d", expectedUserHash, agg.UserHashes[0])
 	}
 }
+
+func TestDecklogUsageLoggerPreservesBillingAttribution(t *testing.T) {
+	sender := &fakeServiceEventSender{}
+	logger := &DecklogUsageLogger{Client: sender}
+
+	startedAt := time.Now().Add(-1 * time.Second)
+	logger.LogChatUsage(context.Background(), ChatUsageEvent{
+		TenantID:       "tenant-999",
+		UserID:         "user-999",
+		ConversationID: "conv-999",
+		StartedAt:      startedAt,
+		TokensIn:       2,
+		TokensOut:      3,
+		UserHash:       111,
+		TokenHash:      222,
+	})
+
+	if sender.lastEvent == nil {
+		t.Fatal("expected service event to be sent")
+	}
+	if sender.lastEvent.TenantId != "tenant-999" {
+		t.Fatalf("expected tenant-999, got %q", sender.lastEvent.TenantId)
+	}
+	batch := sender.lastEvent.GetApiRequestBatch()
+	if batch == nil || len(batch.Aggregates) != 1 {
+		t.Fatalf("expected one aggregate in batch, got %#v", batch)
+	}
+	agg := batch.Aggregates[0]
+	if agg.TenantId != "tenant-999" {
+		t.Fatalf("expected aggregate tenant-999, got %q", agg.TenantId)
+	}
+	if len(agg.UserHashes) != 1 || agg.UserHashes[0] != 111 {
+		t.Fatalf("expected user hash 111, got %#v", agg.UserHashes)
+	}
+	if len(agg.TokenHashes) != 1 || agg.TokenHashes[0] != 222 {
+		t.Fatalf("expected token hash 222, got %#v", agg.TokenHashes)
+	}
+}


### PR DESCRIPTION
### Motivation

- Increase coverage of tool execution, MCP reconnect behavior, docs-mode allowlist enforcement, and metering/usage emission for the Skipper orchestrator.  
- Validate that MCP client refreshes discovered tools after a reconnect and that mutating tools are not invoked in documentation mode.  
- Ensure usage events preserve tenant/user/token attribution and that chat usage logging captures token counts.

### Description

- Added `TestGatewayClient_ReconnectRefreshesTools` to `api_consultant/internal/mcpclient/client_test.go` to simulate a Gateway MCP reconnect and verify tools are refreshed and registered.  
- Added `TestDocsModeBlocksMutatingToolExecution` and a `countingGateway` test double to `api_consultant/internal/chat/orchestrator_test.go` to confirm docs-mode blocks mutating tool execution and never calls the gateway.  
- Added `captureUsageLogger` and `TestHandleChat_UsageLoggerCapturesTokens` to `api_consultant/internal/chat/handler_test.go` to assert `UsageLogger` receives tenant/user/conversation and non-zero token counts for chat flows.  
- Added `TestDecklogUsageLoggerPreservesBillingAttribution` to `api_consultant/internal/skipper/decklog_adapter_test.go` to verify billing attribution (tenant, user hash, token hash) is preserved in emitted service events.  
- Ran `gofmt -w` on modified test files and updated imports where necessary.

### Testing

- Ran code formatting with `gofmt -w` on the modified test files and committed the changes.  
- Pre-commit hooks (lefthook) completed during commit (format/lint checks ran).  
- Attempted to run unit tests with `cd api_consultant && go test ./...` in the sandbox but the run did not complete inside this session; please run `make test` or `cd api_consultant && go test ./...` locally or in CI to validate all new tests pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698887b0952c8330ad89d3181aae45ed)