### PR TITLE
Improve Listmonk subscribe resilience and add integration tests

### DIFF
--- a/api_forms/go.mod
+++ b/api_forms/go.mod
@@ -13,12 +13,14 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bits-and-blooms/bitset v1.24.4 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.6 // indirect
 	github.com/bytedance/sonic v1.14.0 // indirect
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/failsafe-go/failsafe-go v0.9.5 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.8 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect

--- a/api_forms/go.sum
+++ b/api_forms/go.sum
@@ -2,6 +2,8 @@ github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7Oputl
 github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bits-and-blooms/bitset v1.24.4 h1:95H15Og1clikBrKr/DuzMXkQzECs1M6hhoGXLwLQOZE=
+github.com/bits-and-blooms/bitset v1.24.4/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/btcsuite/btcd/btcec/v2 v2.3.6 h1:IzlsEr9olcSRKB/n7c4351F3xHKxS2lma+1UFGCYd4E=
 github.com/btcsuite/btcd/btcec/v2 v2.3.6/go.mod h1:m22FrOAiuxl/tht9wIqAoGHcbnCCaPWyauO8y2LGGtQ=
 github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0 h1:59Kx4K6lzOW5w6nFlA0v5+lk/6sjybR934QNHSJZPTQ=
@@ -22,6 +24,8 @@ github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
+github.com/failsafe-go/failsafe-go v0.9.5 h1:Bgt4wTKV3+n49GssB2njPZ4u5ApjvtKSIQlqIL4E3oo=
+github.com/failsafe-go/failsafe-go v0.9.5/go.mod h1:IeRpglkcwzKagjDMh90ZhN2l4Ovt3+jemQBUbThag54=
 github.com/gabriel-vasile/mimetype v1.4.8 h1:FfZ3gj38NjllZIeJAmMhr+qKL8Wu+nOoI3GqacKw1NM=
 github.com/gabriel-vasile/mimetype v1.4.8/go.mod h1:ByKUIKGjh1ODkGM1asKUbQZOLGrPjydw3hYPU2YU9t8=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=
@@ -53,6 +57,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/influxdata/tdigest v0.0.1 h1:XpFptwYmnEKUqmkcDjrzffswZ3nvNeevbUSLPP/ZzIY=
+github.com/influxdata/tdigest v0.0.1/go.mod h1:Z0kXnxzbTC2qrx4NaIzYkE1k66+6oEDQTvL95hQFh5Y=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -98,8 +104,8 @@ github.com/quic-go/qpack v0.6.0 h1:g7W+BMYynC1LbYLSqRt8PBg5Tgwxn214ZZR34VIOjz8=
 github.com/quic-go/qpack v0.6.0/go.mod h1:lUpLKChi8njB4ty2bFLX2x4gzDqXwUpaO1DP9qMDZII=
 github.com/quic-go/quic-go v0.57.0 h1:AsSSrrMs4qI/hLrKlTH/TGQeTMY0ib1pAOX7vA3AdqE=
 github.com/quic-go/quic-go v0.57.0/go.mod h1:ly4QBAjHA2VhdnxhojRsCUOeJwKYg+taDlos92xb1+s=
-github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
-github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/api_forms/internal/handlers/subscribe_test.go
+++ b/api_forms/internal/handlers/subscribe_test.go
@@ -6,14 +6,18 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
+	"frameworks/pkg/clients"
 	"frameworks/pkg/clients/listmonk"
 	"frameworks/pkg/logging"
 
 	"github.com/gin-gonic/gin"
 )
+
+// --- Stub-based unit tests ---
 
 type listmonkStub struct {
 	subscribeCalls []subscribeCall
@@ -257,4 +261,230 @@ func TestSubscribeHandlesListmonkConflict(t *testing.T) {
 	if harness.stub.subscribeCalls[0].email != "user@example.com" {
 		t.Fatalf("expected normalized email, got %s", harness.stub.subscribeCalls[0].email)
 	}
+}
+
+// --- Integration tests (real listmonk client with httptest servers) ---
+
+func TestSubscribeRetriesWithBackoff(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var mu sync.Mutex
+	var postTimes []time.Time
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"results":[]}}`))
+		case http.MethodPost:
+			mu.Lock()
+			postTimes = append(postTimes, time.Now())
+			attempt := len(postTimes)
+			mu.Unlock()
+
+			if attempt == 1 {
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	executorCfg := clients.HTTPExecutorConfig{
+		MaxRetries:  1,
+		BaseDelay:   25 * time.Millisecond,
+		MaxDelay:    25 * time.Millisecond,
+		ShouldRetry: clients.DefaultShouldRetry,
+	}
+	httpClient := &http.Client{Timeout: 500 * time.Millisecond}
+	lmClient := listmonk.NewClient(
+		server.URL,
+		"user",
+		"pass",
+		listmonk.WithHTTPClient(httpClient),
+		listmonk.WithHTTPExecutorConfig(executorCfg),
+	)
+
+	handler := NewSubscribeHandler(lmClient, nil, 42, false, logging.NewLogger())
+	router := gin.New()
+	router.POST("/api/subscribe", handler.Handle)
+
+	body := newSubscribeBody(t, "retry@example.com")
+	req := httptest.NewRequest(http.MethodPost, "/api/subscribe", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", recorder.Code)
+	}
+
+	mu.Lock()
+	if len(postTimes) != 2 {
+		mu.Unlock()
+		t.Fatalf("expected 2 POST attempts, got %d", len(postTimes))
+	}
+	delay := postTimes[1].Sub(postTimes[0])
+	mu.Unlock()
+
+	if delay < executorCfg.BaseDelay {
+		t.Fatalf("expected retry delay >= %s, got %s", executorCfg.BaseDelay, delay)
+	}
+}
+
+func TestSubscribeSuppressesDuplicateSubmission(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var mu sync.Mutex
+	getCount := 0
+	postCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		defer mu.Unlock()
+		switch r.Method {
+		case http.MethodGet:
+			getCount++
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"results":[{"id":12,"status":"enabled","lists":[{"id":42,"subscription_status":"confirmed"}]}]}}`))
+		case http.MethodPost:
+			postCount++
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	httpClient := &http.Client{Timeout: 500 * time.Millisecond}
+	lmClient := listmonk.NewClient(
+		server.URL,
+		"user",
+		"pass",
+		listmonk.WithHTTPClient(httpClient),
+	)
+
+	handler := NewSubscribeHandler(lmClient, nil, 42, false, logging.NewLogger())
+	router := gin.New()
+	router.POST("/api/subscribe", handler.Handle)
+
+	body := newSubscribeBody(t, "dupe@example.com")
+	req := httptest.NewRequest(http.MethodPost, "/api/subscribe", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", recorder.Code)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if payload["success"] != true {
+		t.Fatalf("expected success true, got %v", payload["success"])
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if getCount != 1 {
+		t.Fatalf("expected 1 GET request, got %d", getCount)
+	}
+	if postCount != 0 {
+		t.Fatalf("expected 0 POST requests for duplicate, got %d", postCount)
+	}
+}
+
+func TestSubscribeTimeoutReturnsGatewayTimeout(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	var mu sync.Mutex
+	postCount := 0
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"results":[]}}`))
+		case http.MethodPost:
+			mu.Lock()
+			postCount++
+			mu.Unlock()
+			time.Sleep(50 * time.Millisecond)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	executorCfg := clients.HTTPExecutorConfig{
+		MaxRetries:  1,
+		BaseDelay:   5 * time.Millisecond,
+		MaxDelay:    5 * time.Millisecond,
+		ShouldRetry: clients.DefaultShouldRetry,
+	}
+	httpClient := &http.Client{Timeout: 10 * time.Millisecond}
+	lmClient := listmonk.NewClient(
+		server.URL,
+		"user",
+		"pass",
+		listmonk.WithHTTPClient(httpClient),
+		listmonk.WithHTTPExecutorConfig(executorCfg),
+	)
+
+	handler := NewSubscribeHandler(lmClient, nil, 42, false, logging.NewLogger())
+	router := gin.New()
+	router.POST("/api/subscribe", handler.Handle)
+
+	body := newSubscribeBody(t, "timeout@example.com")
+	req := httptest.NewRequest(http.MethodPost, "/api/subscribe", bytes.NewBuffer(body))
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusGatewayTimeout {
+		t.Fatalf("expected status 504, got %d", recorder.Code)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(recorder.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if payload["error"] != "Subscription service timeout" {
+		t.Fatalf("expected timeout error message, got %v", payload["error"])
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if postCount != 2 {
+		t.Fatalf("expected 2 POST attempts, got %d", postCount)
+	}
+}
+
+func newSubscribeBody(t *testing.T, email string) []byte {
+	t.Helper()
+	payload := map[string]any{
+		"email":       email,
+		"name":        "Test User",
+		"human_check": "human",
+		"behavior": map[string]any{
+			"formShownAt": 0,
+			"submittedAt": 4000,
+			"mouse":       true,
+			"typed":       true,
+		},
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal request: %v", err)
+	}
+	return body
 }


### PR DESCRIPTION
### Motivation
- Downstream Listmonk calls were a source of flakiness and unclear error semantics, causing intermittent failures in the Forms API. 
- The subscribe flow needed idempotent behavior to suppress duplicate submissions when a user is already confirmed in the target list. 
- Tests were required to assert timeout/retry/backoff behavior and to pin deterministic error responses for operators and clients. 

### Description
- Extended the Listmonk HTTP client (`pkg/clients/listmonk/client.go`) to support configurable retry/backoff via the existing HTTP executor abstraction, added options (`WithHTTPClient`, `WithHTTPExecutorConfig`, `WithHTTPExecutor`) and a `doRequest` wrapper to make requests retry-safe while ensuring request body handling is safe for retries. 
- Made the subscribe handler idempotent and deterministic (`api_forms/internal/handlers/subscribe.go`) by checking `GetSubscriber` before sending a `Subscribe` call, and centralizing downstream error responses with `respondListmonkError` and `isTimeoutError` to return consistent `504 Gateway Timeout` or `502 Bad Gateway` semantics. 
- Added focused tests (`api_forms/internal/handlers/subscribe_test.go`) that cover retry/backoff semantics, duplicate-submission suppression, and timeout handling against an `httptest` server. 
- Updated `api_forms` module files (`go.mod` and `go.sum`) to include the transient dependency introduced for retries. 

### Testing
- Ran code formatting with `gofmt` on modified files and committed the changes. 
- Resolved dependency bookkeeping by running `cd api_forms && go mod tidy` to populate `go.sum`. 
- Executed the targeted test suite with `cd api_forms && timeout 60s go test ./internal/handlers -count=1`, which passed (`ok frameworks/api_forms/internal/handlers`). 
- An initial attempt to run `cd api_forms && go test ./...` failed due to missing `go.sum` entries before `go mod tidy`, which was fixed and caused the focused handler tests to pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69888aa45e688330900a54d6866cd79d)