### PR TITLE
Add unit tests for core player modules (BasePlayer, EventEmitter, MetaTrackManager, TelemetryReporter, PlayerRegistry, FrameWorksPlayer, utils)

### DIFF
--- a/npm_player/packages/core/test/event-emitter.test.ts
+++ b/npm_player/packages/core/test/event-emitter.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { TypedEventEmitter } from "../src/core/EventEmitter";
+
+interface TestEvents {
+  alpha: { value: number };
+  beta: string;
+}
+
+class TestEmitter extends TypedEventEmitter<TestEvents> {
+  emitPublic<K extends keyof TestEvents>(event: K, data: TestEvents[K]) {
+    this.emit(event, data);
+  }
+}
+
+describe("TypedEventEmitter", () => {
+  it("on returns unsubscribe and emits payload", () => {
+    const emitter = new TestEmitter();
+    const listener = vi.fn();
+
+    const unsub = emitter.on("alpha", listener);
+    emitter.emitPublic("alpha", { value: 7 });
+
+    expect(listener).toHaveBeenCalledWith({ value: 7 });
+
+    unsub();
+    emitter.emitPublic("alpha", { value: 9 });
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it("once fires only one time", () => {
+    const emitter = new TestEmitter();
+    const listener = vi.fn();
+
+    emitter.once("beta", listener);
+    emitter.emitPublic("beta", "first");
+    emitter.emitPublic("beta", "second");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith("first");
+  });
+
+  it("off removes specific listener", () => {
+    const emitter = new TestEmitter();
+    const listener = vi.fn();
+
+    emitter.on("alpha", listener);
+    emitter.off("alpha", listener);
+    emitter.emitPublic("alpha", { value: 1 });
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it("emit isolates listener errors and logs", () => {
+    const emitter = new TestEmitter();
+    const good = vi.fn();
+    const bad = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    emitter.on("beta", bad);
+    emitter.on("beta", good);
+
+    emitter.emitPublic("beta", "payload");
+
+    expect(good).toHaveBeenCalledWith("payload");
+    expect(errorSpy).toHaveBeenCalledWith(
+      "[EventEmitter] Error in beta listener:",
+      expect.any(Error)
+    );
+  });
+
+  it("removeAllListeners and removeListeners clear subscriptions", () => {
+    const emitter = new TestEmitter();
+    const listener = vi.fn();
+
+    emitter.on("alpha", listener);
+    emitter.on("beta", listener);
+
+    emitter.removeListeners("alpha");
+    expect(emitter.hasListeners("alpha")).toBe(false);
+    expect(emitter.hasListeners("beta")).toBe(true);
+
+    emitter.removeAllListeners();
+    expect(emitter.hasListeners("beta")).toBe(false);
+  });
+
+  it("hasListeners reports presence", () => {
+    const emitter = new TestEmitter();
+    const listener = vi.fn();
+
+    expect(emitter.hasListeners("alpha")).toBe(false);
+    emitter.on("alpha", listener);
+    expect(emitter.hasListeners("alpha")).toBe(true);
+  });
+});

--- a/npm_player/packages/core/test/frameworks-player.test.ts
+++ b/npm_player/packages/core/test/frameworks-player.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { FrameWorksPlayer } from "../src/vanilla/FrameWorksPlayer";
+
+class MockElement {}
+
+const { MockPlayerController } = vi.hoisted(() => {
+  class MockPlayerController {
+    static instances: MockPlayerController[] = [];
+
+    config: any;
+    attach = vi.fn().mockResolvedValue(undefined);
+    destroy = vi.fn();
+    play = vi.fn().mockResolvedValue(undefined);
+    pause = vi.fn();
+    seek = vi.fn();
+    setVolume = vi.fn();
+    setMuted = vi.fn();
+    setPlaybackRate = vi.fn();
+    jumpToLive = vi.fn();
+    requestFullscreen = vi.fn().mockResolvedValue(undefined);
+    requestPiP = vi.fn().mockResolvedValue(undefined);
+    getState = vi.fn().mockReturnValue("idle");
+    getStreamState = vi.fn().mockReturnValue(null);
+    getVideoElement = vi.fn().mockReturnValue(null);
+    isReady = vi.fn().mockReturnValue(false);
+    getCurrentTime = vi.fn().mockReturnValue(0);
+    getDuration = vi.fn().mockReturnValue(0);
+    isPaused = vi.fn().mockReturnValue(true);
+    isMuted = vi.fn().mockReturnValue(false);
+    retry = vi.fn().mockResolvedValue(undefined);
+    getMetadata = vi.fn().mockReturnValue({});
+    getStats = vi.fn().mockResolvedValue({});
+    getLatency = vi.fn().mockResolvedValue({});
+    on = vi.fn((_event: string, _listener: Function) => vi.fn());
+
+    constructor(config: any) {
+      this.config = config;
+      MockPlayerController.instances.push(this);
+    }
+  }
+
+  return { MockPlayerController };
+});
+
+vi.mock("../src/core/PlayerController", () => ({
+  PlayerController: MockPlayerController,
+}));
+
+describe("FrameWorksPlayer", () => {
+  let origDocument: typeof globalThis.document;
+  let origHTMLElement: any;
+
+  beforeEach(() => {
+    origDocument = globalThis.document;
+    origHTMLElement = (globalThis as any).HTMLElement;
+    (globalThis as any).HTMLElement = MockElement;
+
+    (globalThis as any).document = {
+      querySelector: vi.fn(() => new MockElement()),
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as any).document = origDocument;
+    (globalThis as any).HTMLElement = origHTMLElement;
+    MockPlayerController.instances = [];
+    vi.restoreAllMocks();
+  });
+
+  it("constructs with selector and normalizes options", () => {
+    const player = new FrameWorksPlayer("#player", {
+      contentId: "content",
+      contentType: "vod",
+      gatewayUrl: "https://gateway.test",
+      autoplay: false,
+      muted: false,
+      controls: false,
+      poster: "poster.png",
+      debug: true,
+    });
+
+    const instance = MockPlayerController.instances[0];
+    expect(instance.config).toEqual({
+      contentId: "content",
+      contentType: "vod",
+      endpoints: undefined,
+      gatewayUrl: "https://gateway.test",
+      authToken: undefined,
+      autoplay: false,
+      muted: false,
+      controls: false,
+      poster: "poster.png",
+      debug: true,
+    });
+
+    expect(player.getState()).toBe("idle");
+  });
+
+  it("supports legacy options format", () => {
+    new FrameWorksPlayer(new MockElement() as any, {
+      contentId: "legacy",
+      contentType: "live",
+      thumbnailUrl: "thumb.png",
+      options: {
+        gatewayUrl: "https://legacy",
+        autoplay: true,
+        muted: true,
+        controls: true,
+        debug: false,
+        authToken: "token",
+      },
+    });
+
+    const instance = MockPlayerController.instances[0];
+    expect(instance.config.gatewayUrl).toBe("https://legacy");
+    expect(instance.config.poster).toBe("thumb.png");
+    expect(instance.config.authToken).toBe("token");
+  });
+
+  it("throws when container is invalid", () => {
+    (globalThis as any).document.querySelector = vi.fn(() => null);
+    expect(
+      () =>
+        new FrameWorksPlayer("#missing", {
+          contentId: "content",
+          contentType: "live",
+        })
+    ).toThrow("Container element not found");
+  });
+
+  it("wires up callbacks and delegates controls", async () => {
+    const onStateChange = vi.fn();
+    const onStreamStateChange = vi.fn();
+    const onTimeUpdate = vi.fn();
+    const onError = vi.fn();
+    const onReady = vi.fn();
+
+    const player = new FrameWorksPlayer("#player", {
+      contentId: "content",
+      contentType: "vod",
+      onStateChange,
+      onStreamStateChange,
+      onTimeUpdate,
+      onError,
+      onReady,
+    });
+
+    const instance = MockPlayerController.instances[0];
+    expect(instance.on).toHaveBeenCalledWith("stateChange", expect.any(Function));
+    expect(instance.on).toHaveBeenCalledWith("streamStateChange", expect.any(Function));
+    expect(instance.on).toHaveBeenCalledWith("timeUpdate", expect.any(Function));
+    expect(instance.on).toHaveBeenCalledWith("error", expect.any(Function));
+    expect(instance.on).toHaveBeenCalledWith("ready", expect.any(Function));
+
+    await player.play();
+    player.pause();
+    player.seek(10);
+    player.setVolume(0.5);
+    player.setMuted(true);
+    player.setPlaybackRate(1.5);
+    player.jumpToLive();
+    await player.requestFullscreen();
+    await player.requestPiP();
+
+    expect(instance.play).toHaveBeenCalledTimes(1);
+    expect(instance.pause).toHaveBeenCalledTimes(1);
+    expect(instance.seek).toHaveBeenCalledWith(10);
+    expect(instance.setVolume).toHaveBeenCalledWith(0.5);
+    expect(instance.setMuted).toHaveBeenCalledWith(true);
+    expect(instance.setPlaybackRate).toHaveBeenCalledWith(1.5);
+    expect(instance.jumpToLive).toHaveBeenCalledTimes(1);
+    expect(instance.requestFullscreen).toHaveBeenCalledTimes(1);
+    expect(instance.requestPiP).toHaveBeenCalledTimes(1);
+
+    player.retry();
+    player.getMetadata();
+    player.getStats();
+    player.getLatency();
+
+    expect(instance.retry).toHaveBeenCalledTimes(1);
+    expect(instance.getMetadata).toHaveBeenCalledTimes(1);
+    expect(instance.getStats).toHaveBeenCalledTimes(1);
+    expect(instance.getLatency).toHaveBeenCalledTimes(1);
+
+    player.destroy();
+    player.destroy();
+
+    expect(instance.destroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/npm_player/packages/core/test/meta-track-manager.test.ts
+++ b/npm_player/packages/core/test/meta-track-manager.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MetaTrackManager } from "../src/core/MetaTrackManager";
+import type { MetaTrackEvent } from "../src/types";
+
+class MockWebSocket {
+  static OPEN = 1;
+  static instances: MockWebSocket[] = [];
+
+  readyState = MockWebSocket.OPEN;
+  onopen: (() => void) | null = null;
+  onmessage: ((e: { data: string }) => void) | null = null;
+  onclose: (() => void) | null = null;
+  onerror: ((e: any) => void) | null = null;
+  send = vi.fn();
+  close = vi.fn(() => {
+    this.onclose?.();
+  });
+
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+  }
+}
+
+describe("MetaTrackManager", () => {
+  let originalWebSocket: typeof globalThis.WebSocket;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    originalWebSocket = globalThis.WebSocket;
+    (globalThis as any).WebSocket = MockWebSocket;
+    MockWebSocket.instances = [];
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    (globalThis as any).WebSocket = originalWebSocket;
+    vi.restoreAllMocks();
+  });
+
+  it("uses defaults and builds websocket URL", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "https://mist.test", streamName: "abc" });
+
+    expect((manager as any).bufferAhead).toBe(5);
+    expect((manager as any).maxMessageAge).toBe(5);
+    expect((manager as any).fastForwardInterval).toBe(5);
+
+    expect((manager as any).buildWsUrl()).toBe("wss://mist.test/json_abc.js?rate=1");
+  });
+
+  it("connects with debounce, sends tracks and seek", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "http://mist.test", streamName: "abc" });
+    manager.subscribe("1", vi.fn());
+
+    manager.connect();
+    manager.connect();
+
+    expect(MockWebSocket.instances).toHaveLength(0);
+    vi.advanceTimersByTime(100);
+
+    expect(MockWebSocket.instances).toHaveLength(1);
+    const ws = MockWebSocket.instances[0];
+    ws.onopen?.();
+
+    expect(ws.send).toHaveBeenCalledTimes(2);
+    const [tracks, seek] = ws.send.mock.calls.map((call) => JSON.parse(call[0]));
+    expect(tracks).toEqual({ type: "tracks", meta: "1" });
+    expect(seek).toEqual({ type: "seek", seek_time: 0, ff_to: 5000 });
+  });
+
+  it("disconnect closes socket and clears timers", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "http://mist.test", streamName: "abc" });
+    manager.connect();
+    vi.advanceTimersByTime(100);
+
+    const ws = MockWebSocket.instances[0];
+    ws.onopen?.();
+
+    manager.disconnect();
+    expect(ws.close).toHaveBeenCalledTimes(1);
+    expect(manager.getState()).toBe("disconnected");
+  });
+
+  it("updates subscriptions and sends track updates", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "http://mist.test", streamName: "abc" });
+    const ws = new MockWebSocket("ws://mock");
+    (manager as any).ws = ws as unknown as WebSocket;
+    (manager as any).state = "connected";
+
+    const cb = vi.fn();
+    const unsub = manager.subscribe("2", cb);
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "tracks", meta: "2" }));
+
+    unsub();
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "tracks", meta: "" }));
+  });
+
+  it("buffers subtitle events and dispatches when due", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "http://mist.test", streamName: "abc" });
+    const cb = vi.fn();
+    manager.subscribe("1", cb);
+
+    (manager as any).handleMessage(
+      JSON.stringify({ time: 1000, track: 1, data: { text: "Hello", startTime: 1 } })
+    );
+
+    expect(cb).not.toHaveBeenCalled();
+
+    manager.setPlaybackTime(1);
+    expect(cb).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "subtitle", trackId: "1", timestamp: 1000 })
+    );
+  });
+
+  it("dispatches non-timed events immediately", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "http://mist.test", streamName: "abc" });
+    const cb = vi.fn();
+    manager.subscribe("1", cb);
+
+    (manager as any).handleMessage(
+      JSON.stringify({ time: 2000, track: 1, data: { key: "score", value: 1 } })
+    );
+
+    expect(cb).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "score", trackId: "1", timestamp: 2000 })
+    );
+  });
+
+  it("handles on_time hold and seek messages", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "http://mist.test", streamName: "abc" });
+    const ws = new MockWebSocket("ws://mock");
+    (manager as any).ws = ws as unknown as WebSocket;
+    (manager as any).state = "connected";
+
+    (manager as any).handleMessage(JSON.stringify({ type: "on_time", data: { current: 40000 } }));
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "hold" }));
+
+    (manager as any).addToTimedBuffer({
+      type: "subtitle",
+      timestamp: 1000,
+      trackId: "1",
+      data: {},
+    } as MetaTrackEvent);
+
+    expect((manager as any).timedEventBuffer.size).toBe(1);
+    (manager as any).handleMessage(JSON.stringify({ type: "seek" }));
+    expect((manager as any).timedEventBuffer.size).toBe(0);
+  });
+
+  it("detects event types", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "http://mist.test", streamName: "abc" });
+
+    expect((manager as any).detectEventType({ text: "hi", startTime: 1 })).toBe("subtitle");
+    expect((manager as any).detectEventType({ key: "k", value: 2 })).toBe("score");
+    expect((manager as any).detectEventType({ title: "Chap", startTime: 1 })).toBe("chapter");
+    expect((manager as any).detectEventType({ name: "evt" })).toBe("event");
+    expect((manager as any).detectEventType(123)).toBe("unknown");
+  });
+
+  it("manages timed buffer and fast-forward", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "http://mist.test", streamName: "abc" });
+    const ws = new MockWebSocket("ws://mock");
+    (manager as any).ws = ws as unknown as WebSocket;
+    (manager as any).state = "connected";
+
+    (manager as any).addToTimedBuffer({
+      type: "subtitle",
+      timestamp: 5000,
+      trackId: "1",
+      data: {},
+    } as MetaTrackEvent);
+
+    (manager as any).addToTimedBuffer({
+      type: "subtitle",
+      timestamp: 2000,
+      trackId: "1",
+      data: {},
+    } as MetaTrackEvent);
+
+    expect(manager.needsMoreData("1")).toBe(false);
+    manager.setPlaybackTime(1);
+    expect(manager.needsMoreData("1")).toBe(true);
+
+    vi.setSystemTime(6000);
+    manager.fastForward();
+    expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "fast_forward", ff_to: 6000 }));
+
+    vi.setSystemTime(7000);
+    manager.fastForward();
+    expect(ws.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("reconnects with backoff after close", () => {
+    const manager = new MetaTrackManager({ mistBaseUrl: "http://mist.test", streamName: "abc" });
+    manager.connect();
+    vi.advanceTimersByTime(100);
+
+    const ws = MockWebSocket.instances[0];
+    ws.onopen?.();
+
+    ws.onclose?.();
+    expect(manager.getState()).toBe("reconnecting");
+
+    vi.advanceTimersByTime(1100);
+    expect(MockWebSocket.instances.length).toBe(2);
+  });
+});

--- a/npm_player/packages/core/test/player-interface.test.ts
+++ b/npm_player/packages/core/test/player-interface.test.ts
@@ -1,0 +1,309 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BasePlayer } from "../src/core/PlayerInterface";
+
+class TestPlayer extends BasePlayer {
+  readonly capability = {
+    name: "Test",
+    shortname: "test",
+    priority: 1,
+    mimes: ["test/video"],
+  };
+
+  isMimeSupported(mime: string) {
+    return mime === "test/video";
+  }
+
+  isBrowserSupported() {
+    return ["video" as const];
+  }
+
+  async initialize() {
+    return this.videoElement!;
+  }
+
+  destroy() {}
+
+  setVideoElement(el: HTMLVideoElement | null) {
+    this.videoElement = el;
+  }
+
+  callSetupVideoEventListeners(v: HTMLVideoElement, o: any) {
+    this.setupVideoEventListeners(v, o);
+  }
+
+  callEmit(event: string, data: any) {
+    this.emit(event as any, data);
+  }
+}
+
+function createMockVideo() {
+  const listeners = new Map<string, Function[]>();
+  return {
+    currentTime: 0,
+    duration: 100,
+    paused: false,
+    muted: false,
+    volume: 1,
+    playbackRate: 1,
+    videoWidth: 1920,
+    videoHeight: 1080,
+    error: null as any,
+    textTracks: [] as any,
+    buffered: { length: 1, start: () => 0, end: () => 60 },
+    seekable: { length: 1, start: () => 0, end: () => 100 },
+    style: { width: "", height: "" },
+    play: vi.fn(async () => {}),
+    pause: vi.fn(),
+    addEventListener: vi.fn((event: string, handler: Function) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event)!.push(handler);
+    }),
+    removeEventListener: vi.fn(),
+    requestPictureInPicture: vi.fn(async () => {}),
+    getVideoPlaybackQuality: vi.fn(() => ({ totalVideoFrames: 100, droppedVideoFrames: 2 })),
+    _fire(event: string) {
+      listeners.get(event)?.forEach((h) => h());
+    },
+    _listeners: listeners,
+  } as unknown as HTMLVideoElement;
+}
+
+describe("BasePlayer", () => {
+  let origDocument: typeof globalThis.document;
+
+  beforeEach(() => {
+    origDocument = globalThis.document;
+    (globalThis as any).document = {
+      pictureInPictureElement: null,
+      exitPictureInPicture: vi.fn(async () => {}),
+    };
+  });
+
+  afterEach(() => {
+    (globalThis as any).document = origDocument;
+    vi.restoreAllMocks();
+  });
+
+  it("on/off/emit manages listeners and isolates errors", () => {
+    const player = new TestPlayer();
+    const goodListener = vi.fn();
+    const badListener = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    player.on("play", badListener);
+    player.on("play", goodListener);
+
+    player.callEmit("play", undefined);
+
+    expect(goodListener).toHaveBeenCalledTimes(1);
+    expect(errorSpy).toHaveBeenCalledWith("Error in play listener:", expect.any(Error));
+
+    player.off("play", goodListener);
+    player.callEmit("play", undefined);
+
+    expect(goodListener).toHaveBeenCalledTimes(1);
+  });
+
+  it("setupVideoEventListeners wires events and fires onReady last", () => {
+    const player = new TestPlayer();
+    const video = createMockVideo();
+    const order: string[] = [];
+    const callbacks = {
+      onPlay: vi.fn(),
+      onPause: vi.fn(),
+      onEnded: vi.fn(),
+      onWaiting: vi.fn(),
+      onPlaying: vi.fn(),
+      onCanPlay: vi.fn(),
+      onDurationChange: vi.fn(),
+      onTimeUpdate: vi.fn(),
+      onError: vi.fn(),
+      onReady: vi.fn(() => order.push("onReady")),
+    };
+
+    player.on("ready", () => order.push("emit-ready"));
+    const onPlayEmit = vi.fn();
+    const onPauseEmit = vi.fn();
+    const onEndedEmit = vi.fn();
+    const onTimeUpdateEmit = vi.fn();
+    const onErrorEmit = vi.fn();
+
+    player.on("play", onPlayEmit);
+    player.on("pause", onPauseEmit);
+    player.on("ended", onEndedEmit);
+    player.on("timeupdate", onTimeUpdateEmit);
+    player.on("error", onErrorEmit);
+
+    player.callSetupVideoEventListeners(video, callbacks);
+
+    expect(order).toEqual(["emit-ready", "onReady"]);
+    expect(video._listeners.has("play")).toBe(true);
+    expect(video._listeners.has("pause")).toBe(true);
+    expect(video._listeners.has("ended")).toBe(true);
+    expect(video._listeners.has("waiting")).toBe(true);
+    expect(video._listeners.has("playing")).toBe(true);
+    expect(video._listeners.has("canplay")).toBe(true);
+    expect(video._listeners.has("durationchange")).toBe(true);
+    expect(video._listeners.has("timeupdate")).toBe(true);
+    expect(video._listeners.has("error")).toBe(true);
+
+    video._fire("play");
+    expect(callbacks.onPlay).toHaveBeenCalledTimes(1);
+    expect(onPlayEmit).toHaveBeenCalledTimes(1);
+
+    video._fire("pause");
+    expect(callbacks.onPause).toHaveBeenCalledTimes(1);
+    expect(onPauseEmit).toHaveBeenCalledTimes(1);
+
+    video._fire("ended");
+    expect(callbacks.onEnded).toHaveBeenCalledTimes(1);
+    expect(onEndedEmit).toHaveBeenCalledTimes(1);
+
+    video._fire("waiting");
+    expect(callbacks.onWaiting).toHaveBeenCalledTimes(1);
+
+    video._fire("playing");
+    expect(callbacks.onPlaying).toHaveBeenCalledTimes(1);
+
+    video._fire("canplay");
+    expect(callbacks.onCanPlay).toHaveBeenCalledTimes(1);
+
+    video.currentTime = 12.5;
+    video._fire("timeupdate");
+    expect(callbacks.onTimeUpdate).toHaveBeenCalledWith(12.5);
+    expect(onTimeUpdateEmit).toHaveBeenCalledWith(12.5);
+
+    video.error = { message: "nope" } as any;
+    video._fire("error");
+    expect(callbacks.onError).toHaveBeenCalledWith("Video error: nope");
+    expect(onErrorEmit).toHaveBeenCalledWith("Video error: nope");
+
+    video.duration = 75;
+    video._fire("durationchange");
+    expect(callbacks.onDurationChange).toHaveBeenCalledWith(75);
+  });
+
+  it("returns playback state defaults when no video element", async () => {
+    const player = new TestPlayer();
+
+    expect(player.getCurrentTime()).toBe(0);
+    expect(player.getDuration()).toBe(0);
+    expect(player.isPaused()).toBe(true);
+    expect(player.isMuted()).toBe(false);
+
+    await expect(player.play()).resolves.toBeUndefined();
+    player.pause();
+    player.seek(10);
+    player.setVolume(0.5);
+    player.setMuted(true);
+    player.setPlaybackRate(1.5);
+    player.setSize(100, 200);
+  });
+
+  it("delegates playback controls to video element", async () => {
+    const player = new TestPlayer();
+    const video = createMockVideo();
+    player.setVideoElement(video);
+
+    expect(player.getCurrentTime()).toBe(0);
+    expect(player.getDuration()).toBe(100);
+    expect(player.isPaused()).toBe(false);
+    expect(player.isMuted()).toBe(false);
+
+    await player.play();
+    expect(video.play).toHaveBeenCalledTimes(1);
+
+    player.pause();
+    expect(video.pause).toHaveBeenCalledTimes(1);
+
+    player.seek(33);
+    expect(video.currentTime).toBe(33);
+
+    player.setVolume(2);
+    expect(video.volume).toBe(1);
+    player.setVolume(-1);
+    expect(video.volume).toBe(0);
+
+    player.setMuted(true);
+    expect(video.muted).toBe(true);
+
+    player.setPlaybackRate(1.25);
+    expect(video.playbackRate).toBe(1.25);
+  });
+
+  it("maps text tracks and selects by id", () => {
+    const player = new TestPlayer();
+    const video = createMockVideo();
+    const tracks = [
+      { label: "", language: "en", mode: "disabled" },
+      { label: "English", language: "en", mode: "showing" },
+    ];
+    (video as any).textTracks = tracks;
+    player.setVideoElement(video);
+
+    const mapped = player.getTextTracks();
+    expect(mapped).toEqual([
+      { id: "0", label: "CC 1", lang: "en", active: false },
+      { id: "1", label: "English", lang: "en", active: true },
+    ]);
+
+    player.selectTextTrack("0");
+    expect(tracks[0].mode).toBe("showing");
+    expect(tracks[1].mode).toBe("disabled");
+
+    player.selectTextTrack(null);
+    expect(tracks[0].mode).toBe("disabled");
+    expect(tracks[1].mode).toBe("disabled");
+  });
+
+  it("detects live streams and jumps to live edge", () => {
+    const player = new TestPlayer();
+    const video = createMockVideo();
+    player.setVideoElement(video);
+
+    video.duration = Infinity;
+    expect(player.isLive()).toBe(true);
+
+    video.duration = 120;
+    expect(player.isLive()).toBe(false);
+
+    video.seekable = { length: 1, start: () => 0, end: () => 88 } as any;
+    player.jumpToLive();
+    expect(video.currentTime).toBe(88);
+  });
+
+  it("handles Picture-in-Picture requests", async () => {
+    const player = new TestPlayer();
+    const video = createMockVideo();
+    player.setVideoElement(video);
+
+    await player.requestPiP();
+    expect(video.requestPictureInPicture).toHaveBeenCalledTimes(1);
+
+    (globalThis as any).document.pictureInPictureElement = video;
+    await player.requestPiP();
+    expect((globalThis as any).document.exitPictureInPicture).toHaveBeenCalledTimes(1);
+
+    (video as any).requestPictureInPicture = undefined;
+    (video as any).webkitSetPresentationMode = vi.fn();
+    (globalThis as any).document.pictureInPictureElement = null;
+    await player.requestPiP();
+    expect((video as any).webkitSetPresentationMode).toHaveBeenCalledWith("picture-in-picture");
+  });
+
+  it("sets size and returns optional stats defaults", async () => {
+    const player = new TestPlayer();
+    const video = createMockVideo();
+    player.setVideoElement(video);
+
+    player.setSize(320, 240);
+    expect(video.style.width).toBe("320px");
+    expect(video.style.height).toBe("240px");
+
+    await expect(player.getStats()).resolves.toBeUndefined();
+    await expect(player.getLatency()).resolves.toBeUndefined();
+  });
+});

--- a/npm_player/packages/core/test/player-registry.test.ts
+++ b/npm_player/packages/core/test/player-registry.test.ts
@@ -1,0 +1,167 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+const createCapability = (shortname: string) => ({
+  name: shortname,
+  shortname,
+  priority: 1,
+  mimes: [],
+});
+
+const constructorSpies = {
+  native: vi.fn(),
+  webcodecs: vi.fn(),
+  mistWebrtc: vi.fn(),
+  videojs: vi.fn(),
+  hlsjs: vi.fn(),
+  dashjs: vi.fn(),
+  mistLegacy: vi.fn(),
+  mews: vi.fn(),
+};
+
+class NativePlayerImpl {
+  capability = createCapability("native");
+  constructor() {
+    constructorSpies.native();
+  }
+}
+class WebCodecsPlayerImpl {
+  capability = createCapability("webcodecs");
+  constructor() {
+    constructorSpies.webcodecs();
+  }
+}
+class MistWebRTCPlayerImpl {
+  capability = createCapability("mist-webrtc");
+  constructor() {
+    constructorSpies.mistWebrtc();
+  }
+}
+class VideoJsPlayerImpl {
+  capability = createCapability("videojs");
+  constructor() {
+    constructorSpies.videojs();
+  }
+}
+class HlsJsPlayerImpl {
+  capability = createCapability("hlsjs");
+  constructor() {
+    constructorSpies.hlsjs();
+  }
+}
+class DashJsPlayerImpl {
+  capability = createCapability("dashjs");
+  constructor() {
+    constructorSpies.dashjs();
+  }
+}
+class MistPlayerImpl {
+  capability = createCapability("mist-legacy");
+  constructor() {
+    constructorSpies.mistLegacy();
+  }
+}
+class MewsWsPlayerImpl {
+  capability = createCapability("mews");
+  constructor() {
+    constructorSpies.mews();
+  }
+}
+
+vi.mock("../src/players/NativePlayer", () => ({ NativePlayerImpl }));
+vi.mock("../src/players/WebCodecsPlayer", () => ({ WebCodecsPlayerImpl }));
+vi.mock("../src/players/MistWebRTCPlayer", () => ({ MistWebRTCPlayerImpl }));
+vi.mock("../src/players/VideoJsPlayer", () => ({ VideoJsPlayerImpl }));
+vi.mock("../src/players/HlsJsPlayer", () => ({ HlsJsPlayerImpl }));
+vi.mock("../src/players/DashJsPlayer", () => ({ DashJsPlayerImpl }));
+vi.mock("../src/players/MistPlayer", () => ({ MistPlayerImpl }));
+vi.mock("../src/players/MewsWsPlayer", () => ({ MewsWsPlayerImpl }));
+
+vi.mock("../src/core/PlayerManager", () => {
+  class PlayerManager {
+    registered: any[] = [];
+    initializeCalls: any[] = [];
+    options?: any;
+
+    constructor(options?: any) {
+      this.options = options;
+    }
+
+    registerPlayer(player: any) {
+      this.registered.push(player);
+    }
+
+    getRegisteredPlayers() {
+      return this.registered;
+    }
+
+    async initializePlayer(...args: any[]) {
+      this.initializeCalls.push(args);
+      return "initialized";
+    }
+  }
+
+  return { PlayerManager };
+});
+
+describe("PlayerRegistry", () => {
+  let registry: typeof import("../src/core/PlayerRegistry");
+  let PlayerManager: typeof import("../src/core/PlayerManager").PlayerManager;
+
+  beforeAll(async () => {
+    registry = await import("../src/core/PlayerRegistry");
+    ({ PlayerManager } = await import("../src/core/PlayerManager"));
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it("loads matching players before initializePlayer", async () => {
+    const manager = new PlayerManager();
+    const streamInfo = {
+      source: [{ url: "u", type: "html5/video/mp4" }],
+      meta: { tracks: [] },
+    };
+
+    await manager.initializePlayer({}, streamInfo, {}, {});
+
+    expect(constructorSpies.native).toHaveBeenCalledTimes(1);
+    expect(manager.getRegisteredPlayers()).toHaveLength(1);
+
+    await manager.initializePlayer({}, streamInfo, {}, {});
+    expect(constructorSpies.native).toHaveBeenCalledTimes(1);
+    expect(manager.initializeCalls).toHaveLength(2);
+
+    await registry.ensurePlayersRegistered(manager);
+  });
+
+  it("loads forced player by shortname", async () => {
+    const manager = new PlayerManager();
+    const streamInfo = {
+      source: [{ url: "u", type: "mist/legacy" }],
+      meta: { tracks: [] },
+    };
+
+    await manager.initializePlayer({}, streamInfo, {}, { forcePlayer: "hlsjs" });
+
+    expect(constructorSpies.mistLegacy).toHaveBeenCalledTimes(1);
+    expect(constructorSpies.hlsjs).toHaveBeenCalledTimes(1);
+  });
+
+  it("deduplicates ensurePlayersRegistered promises", async () => {
+    const manager = new PlayerManager();
+    const p1 = registry.ensurePlayersRegistered(manager);
+    const p2 = registry.ensurePlayersRegistered(manager);
+
+    expect(p1).toBe(p2);
+    await p1;
+  });
+
+  it("creates managers and exposes capabilities", async () => {
+    const manager = registry.createPlayerManager({ debug: true });
+    expect(manager).toBeInstanceOf(PlayerManager);
+    expect((manager as any).options).toEqual({ debug: true });
+
+    const capabilities = registry.getAvailablePlayerCapabilities();
+    expect(capabilities.length).toBeGreaterThan(0);
+  });
+});

--- a/npm_player/packages/core/test/telemetry-reporter.test.ts
+++ b/npm_player/packages/core/test/telemetry-reporter.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { TelemetryReporter } from "../src/core/TelemetryReporter";
+import type { PlaybackQuality } from "../src/types";
+
+function createMockVideo() {
+  const listeners = new Map<string, Function[]>();
+  return {
+    currentTime: 12,
+    duration: 120,
+    paused: false,
+    muted: false,
+    volume: 1,
+    playbackRate: 1,
+    videoWidth: 1920,
+    videoHeight: 1080,
+    error: null as any,
+    buffered: { length: 1, start: () => 0, end: () => 30 },
+    seekable: { length: 1, start: () => 0, end: () => 100 },
+    style: { width: "", height: "" },
+    play: vi.fn(async () => {}),
+    pause: vi.fn(),
+    addEventListener: vi.fn((event: string, handler: Function) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event)!.push(handler);
+    }),
+    removeEventListener: vi.fn((event: string, handler: Function) => {
+      listeners.set(
+        event,
+        (listeners.get(event) || []).filter((h) => h !== handler)
+      );
+    }),
+    requestPictureInPicture: vi.fn(async () => {}),
+    getVideoPlaybackQuality: vi.fn(() => ({ totalVideoFrames: 100, droppedVideoFrames: 2 })),
+    _fire(event: string) {
+      listeners.get(event)?.forEach((h) => h());
+    },
+    _listeners: listeners,
+  } as unknown as HTMLVideoElement;
+}
+
+describe("TelemetryReporter", () => {
+  let origFetch: typeof globalThis.fetch;
+  let origNavigator: any;
+  let origWindow: any;
+  let origCrypto: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    origFetch = globalThis.fetch;
+    origNavigator = globalThis.navigator;
+    origWindow = (globalThis as any).window;
+
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    origCrypto = (globalThis as any).crypto;
+
+    vi.stubGlobal("navigator", { sendBeacon: vi.fn() });
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal("crypto", {
+      getRandomValues: (arr: Uint8Array) => {
+        arr.fill(1);
+        return arr;
+      },
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    globalThis.fetch = origFetch;
+    vi.unstubAllGlobals();
+    if (origNavigator === undefined) {
+      // @ts-expect-error optional
+      delete (globalThis as any).navigator;
+    } else {
+      Object.defineProperty(globalThis, "navigator", {
+        value: origNavigator,
+        configurable: true,
+      });
+    }
+    if (origWindow === undefined) {
+      // @ts-expect-error optional
+      delete (globalThis as any).window;
+    } else {
+      Object.defineProperty(globalThis, "window", { value: origWindow, configurable: true });
+    }
+    if (origCrypto === undefined) {
+      // @ts-expect-error optional
+      delete (globalThis as any).crypto;
+    } else {
+      Object.defineProperty(globalThis, "crypto", { value: origCrypto, configurable: true });
+    }
+    vi.restoreAllMocks();
+  });
+
+  it("uses constructor defaults and starts reporting", async () => {
+    const reporter = new TelemetryReporter({
+      endpoint: "https://telemetry.test",
+      contentId: "content",
+      contentType: "live",
+      playerType: "native",
+      protocol: "hls",
+    });
+
+    const video = createMockVideo();
+    reporter.start(video);
+
+    expect(reporter.isActive()).toBe(true);
+    expect((globalThis.fetch as any).mock.calls[0][0]).toBe("https://telemetry.test");
+
+    vi.advanceTimersByTime(5000);
+    expect(globalThis.fetch).toHaveBeenCalled();
+  });
+
+  it("stops reporting and removes listeners", () => {
+    const reporter = new TelemetryReporter({
+      endpoint: "https://telemetry.test",
+      contentId: "content",
+      contentType: "live",
+      playerType: "native",
+      protocol: "hls",
+    });
+    const video = createMockVideo();
+    reporter.start(video);
+
+    reporter.stop();
+    expect(reporter.isActive()).toBe(false);
+    expect((globalThis.navigator as any).sendBeacon).toHaveBeenCalled();
+    expect((globalThis as any).window.removeEventListener).toHaveBeenCalled();
+  });
+
+  it("records errors and generates payload", () => {
+    const reporter = new TelemetryReporter({
+      endpoint: "https://telemetry.test",
+      contentId: "content",
+      contentType: "vod",
+      playerType: "native",
+      protocol: "hls",
+    });
+    const video = createMockVideo();
+
+    reporter.start(video, () => ({ bitrate: 123, score: 87 }) as PlaybackQuality);
+    reporter.recordError("E1", "oops");
+
+    const payload = (reporter as any).generatePayload();
+    expect(payload.metrics.bitrate).toBe(123);
+    expect(payload.metrics.qualityScore).toBe(87);
+    expect(payload.metrics.bufferedSeconds).toBe(18);
+    expect(payload.metrics.framesDecoded).toBe(100);
+    expect(payload.metrics.framesDropped).toBe(2);
+    expect(payload.errors).toEqual([expect.objectContaining({ code: "E1", message: "oops" })]);
+  });
+
+  it("queues payloads and re-queues on failure", async () => {
+    (globalThis.fetch as any).mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const reporter = new TelemetryReporter({
+      endpoint: "https://telemetry.test",
+      contentId: "content",
+      contentType: "vod",
+      playerType: "native",
+      protocol: "hls",
+      batchSize: 1,
+    });
+    const video = createMockVideo();
+
+    reporter.start(video);
+    await (reporter as any).flush();
+
+    expect((reporter as any).pendingPayloads.length).toBeGreaterThan(0);
+  });
+
+  it("flushSync uses sendBeacon", () => {
+    const reporter = new TelemetryReporter({
+      endpoint: "https://telemetry.test",
+      contentId: "content",
+      contentType: "vod",
+      playerType: "native",
+      protocol: "hls",
+    });
+    const video = createMockVideo();
+
+    reporter.start(video);
+    reporter.stop();
+
+    expect((globalThis.navigator as any).sendBeacon).toHaveBeenCalledWith(
+      "https://telemetry.test",
+      expect.any(Blob)
+    );
+  });
+
+  it("tracks stalls using waiting/playing events", () => {
+    const nowSpy = vi
+      .spyOn(globalThis.performance, "now")
+      .mockReturnValueOnce(100)
+      .mockReturnValueOnce(400);
+
+    const reporter = new TelemetryReporter({
+      endpoint: "https://telemetry.test",
+      contentId: "content",
+      contentType: "vod",
+      playerType: "native",
+      protocol: "hls",
+    });
+    const video = createMockVideo();
+
+    reporter.start(video);
+
+    video._fire("waiting");
+    video._fire("playing");
+
+    const payload = (reporter as any).generatePayload();
+    expect(payload.metrics.stallCount).toBe(1);
+    expect(payload.metrics.totalStallMs).toBe(300);
+
+    nowSpy.mockRestore();
+  });
+});

--- a/npm_player/packages/core/test/utils.test.ts
+++ b/npm_player/packages/core/test/utils.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+
+import { cn } from "../src/lib/utils";
+
+describe("cn", () => {
+  it("merges class names", () => {
+    expect(cn("text-sm", "font-bold")).toBe("text-sm font-bold");
+  });
+
+  it("handles conditional classes", () => {
+    expect(cn("text-sm", false && "hidden", true && "block")).toBe("text-sm block");
+  });
+
+  it("deduplicates tailwind classes", () => {
+    expect(cn("p-2", "p-4", "p-2")).toBe("p-2");
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide mutation-killing unit tests for several previously untested files in `npm_player/packages/core` to reduce surviving Stryker mutants and improve confidence in playback/telemetry/registry logic.

### Description
- Added seven new Vitest test files under `npm_player/packages/core/test/` covering `PlayerInterface` (BasePlayer), `EventEmitter`, `MetaTrackManager`, `TelemetryReporter`, `PlayerRegistry`, `FrameWorksPlayer`, and the `cn` utility. 
- Tests include Node-safe mocks for browser APIs: a mock video element, a mock WebSocket, `navigator.sendBeacon`/`crypto`/`window` stubs, and mocked `PlayerController`/`PlayerManager` implementations to avoid importing heavy modules. 
- Fixed/adjusted test harness details: hoisted mock pattern for `FrameWorksPlayer` to avoid initialization timing issues, replaced simple vi.fn-class mocks with small constructor classes for player registry to behave like real constructors, and aligned expectations with actual `twMerge`/`clsx` behavior for the `cn` test.
- All new test files follow existing patterns used in the repo (explicit global save/restore, `vi.useFakeTimers()` where needed, and explicit assertions of mocked calls and return values).

### Testing
- Ran the package test suite with `pnpm test` in `npm_player/packages/core`; the run produced 27 test files with 718 tests total, of which 697 passed and 21 failed. 
- 26 of 27 test files passed; the sole failing suite is `test/screen-wake-lock.test.ts` (21 failing tests) due to Node environment differences around `navigator`/wakeLock handling that still need addressing. 
- Test run produced the usual Vitest output and JUnit report at `test-results/junit.xml`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988fa39816883308e0f5988e4231c2f)