### PR TITLE
Thread contexts and use context-aware DB APIs in billing + crypto; fix govet shadowing in ticketing gRPC

### DIFF
--- a/api_billing/internal/handlers/checkout_test.go
+++ b/api_billing/internal/handlers/checkout_test.go
@@ -1,6 +1,7 @@
 package handlers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/DATA-DOG/go-sqlmock"
@@ -26,7 +27,7 @@ func TestHandlePrepaidCheckoutCompletedRejectsTenantMismatch(t *testing.T) {
 		WillReturnRows(sqlmock.NewRows([]string{"status", "tenant_id"}).AddRow("pending", "tenant-a"))
 	mock.ExpectRollback()
 
-	if err := handlePrepaidCheckoutCompleted("sess-1", "tenant-b", "topup-123", 1500, "EUR", ProviderStripe); err == nil {
+	if err := handlePrepaidCheckoutCompleted(context.Background(), "sess-1", "tenant-b", "topup-123", 1500, "EUR", ProviderStripe); err == nil {
 		t.Fatal("expected error")
 	}
 

--- a/api_ticketing/internal/grpc/server.go
+++ b/api_ticketing/internal/grpc/server.go
@@ -300,7 +300,7 @@ func (s *Server) ListMessages(ctx context.Context, req *pb.ListMessagesRequest) 
 		return nil, status.Error(codes.InvalidArgument, "invalid conversation_id")
 	}
 
-	if err := s.verifyConversationTenantByID(ctx, convID); err != nil {
+	if err = s.verifyConversationTenantByID(ctx, convID); err != nil {
 		s.metrics.GRPCRequests.WithLabelValues("ListMessages", "forbidden").Inc()
 		return nil, err
 	}
@@ -343,7 +343,7 @@ func (s *Server) SendMessage(ctx context.Context, req *pb.SendMessageRequest) (*
 		return nil, status.Error(codes.InvalidArgument, "content required")
 	}
 
-	if err := s.verifyConversationTenantByID(ctx, convID); err != nil {
+	if err = s.verifyConversationTenantByID(ctx, convID); err != nil {
 		s.metrics.GRPCRequests.WithLabelValues("SendMessage", "forbidden").Inc()
 		return nil, err
 	}


### PR DESCRIPTION
### Motivation
- Ensure database operations respect cancellations/timeouts by using context-aware DB APIs across billing webhook/checkout flows and the crypto monitor.
- Thread `context.Context` through dispatch/handler flows so external timeouts propagate into DB and downstream calls.
- Eliminate `govet` shadowing warnings in ticketing gRPC handlers.

### Description
- Replaced non-contexted DB calls with context-aware variants (`QueryContext`, `QueryRowContext`, `ExecContext`, `BeginTx`, `tx.*Context`) across billing handlers and the crypto monitor and propagated `ctx` where needed.
- Threaded `context.Context` into `DispatchStripeCheckoutCompleted` and downstream handlers (`handleSubscriptionCheckoutCompleted`, `handleClusterSubscriptionCheckoutCompleted`, `handleInvoiceCheckoutCompleted`, `handlePrepaidCheckoutCompleted`) and adjusted call sites including `ProcessStripeWebhookGRPC` (uses `context.Background()` when dispatching).
- Updated `CryptoMonitor` to accept and propagate `ctx` into wallet-checking and confirmation flows and converted confirm helpers to accept `ctx` and use context-aware DB operations.
- Fixed `err` shadowing in ticketing gRPC handlers by reusing the existing `err` variable in `ListMessages` and `SendMessage` tenant checks.
- Files changed include `api_billing/internal/handlers/checkout.go`, `api_billing/internal/handlers/webhooks.go`, `api_billing/internal/handlers/crypto.go`, `api_billing/internal/handlers/checkout_test.go`, and `api_ticketing/internal/grpc/server.go`.

### Testing
- Ran `GOLANGCI_LINT_CACHE=/tmp/golangci-lint-cache make lint-report` and saved `reports/lint-report.txt`, which shows `0 issues` across all modules.
- Ran `make lint-analyze` which completed and produced the lint summary used to validate the changes (no outstanding issues reported in the final lint report).
- A pre-commit lefthook ran during the commit and emitted a warning about missing export data for `frameworks/api_ticketing/internal/chatwoot` while running `go` linters, but the change was committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e75ee19c8330ab3e664ce44336dd)