### PR TITLE
Add tests for stream state parsing, bandwidth logic, and tenant cache invalidation

### DIFF
--- a/api_balancing/internal/grpc/server_test.go
+++ b/api_balancing/internal/grpc/server_test.go
@@ -1,0 +1,79 @@
+package grpc
+
+import (
+	"context"
+	"testing"
+
+	"frameworks/api_balancing/internal/triggers"
+	"frameworks/pkg/logging"
+	pb "frameworks/pkg/proto"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type mockCacheInvalidator struct {
+	lastTenant string
+	entries    int
+}
+
+func (m *mockCacheInvalidator) InvalidateTenantCache(tenantID string) int {
+	m.lastTenant = tenantID
+	return m.entries
+}
+
+func (m *mockCacheInvalidator) GetBillingStatus(ctx context.Context, internalName, tenantID string) *triggers.BillingStatus {
+	return nil
+}
+
+func TestInvalidateTenantCacheRequiresTenantID(t *testing.T) {
+	server := NewFoghornGRPCServer(nil, logging.NewLogger(), nil, nil, nil, nil, nil, nil)
+
+	_, err := server.InvalidateTenantCache(context.Background(), &pb.InvalidateTenantCacheRequest{})
+	if err == nil {
+		t.Fatal("expected error for missing tenant id")
+	}
+
+	statusErr, ok := status.FromError(err)
+	if !ok {
+		t.Fatal("expected grpc status error")
+	}
+	if statusErr.Code() != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument error, got %s", statusErr.Code())
+	}
+}
+
+func TestInvalidateTenantCacheNoInvalidatorConfigured(t *testing.T) {
+	server := NewFoghornGRPCServer(nil, logging.NewLogger(), nil, nil, nil, nil, nil, nil)
+
+	resp, err := server.InvalidateTenantCache(context.Background(), &pb.InvalidateTenantCacheRequest{
+		TenantId: "tenant-1",
+		Reason:   "reactivate",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.EntriesInvalidated != 0 {
+		t.Fatalf("expected 0 invalidated entries, got %d", resp.EntriesInvalidated)
+	}
+}
+
+func TestInvalidateTenantCacheUsesInvalidator(t *testing.T) {
+	server := NewFoghornGRPCServer(nil, logging.NewLogger(), nil, nil, nil, nil, nil, nil)
+	invalidator := &mockCacheInvalidator{entries: 3}
+	server.SetCacheInvalidator(invalidator)
+
+	resp, err := server.InvalidateTenantCache(context.Background(), &pb.InvalidateTenantCacheRequest{
+		TenantId: "tenant-2",
+		Reason:   "reactivate",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.EntriesInvalidated != 3 {
+		t.Fatalf("expected 3 invalidated entries, got %d", resp.EntriesInvalidated)
+	}
+	if invalidator.lastTenant != "tenant-2" {
+		t.Fatalf("expected tenant-2 to be invalidated, got %s", invalidator.lastTenant)
+	}
+}


### PR DESCRIPTION
### Motivation
- Improve unit coverage around stream-state transitions, concurrent-sensitive bandwidth estimates, and edge cases in virtual viewer lifecycle to reduce regressions. 
- Add direct tests for `InvalidateTenantCache` to ensure gRPC handling is correct both with and without a configured invalidator. 

### Description
- Added tests covering `UpdateStreamFromBuffer` parsing and issue handling, invalid JSON handling, and `UpdateTrackList`/`SetOffline` transitions in `api_balancing/internal/state/stream_state_test.go`. 
- Expanded bandwidth-related tests to exercise `calculateEstBandwidthPerUserLocked`, `clampBandwidth`, AddBandwidth saturation, and penalty behavior in `api_balancing/internal/state/stream_state_bandwidth_test.go`. 
- Added gRPC unit tests for `InvalidateTenantCache` (require tenant id, no-invalidator behavior, and use of configured invalidator) in a new file `api_balancing/internal/grpc/server_test.go`. 
- Minor test scaffolding uses `NewStreamStateManager()` / `ResetDefaultManagerForTests()` and exercises state helper APIs (`GetStreamInstances`, `GetStreamState`, etc.).

### Testing
- Ran focused package tests: `cd api_balancing && go test ./internal/state ./internal/grpc`, and all tests passed for those packages. 
- Ran repository linting via `make lint`, which completed but logged a golangci-lint diff-processor warning about a missing baseline git object (informational, not a test failure). 
- Notes: mutation testing was not executed in this change, so mutation coverage gaps remain for some concurrency interleavings; logging side-effects for cache invalidation are not asserted (tests validate return values and invalidator calls only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69893035d73c8330abd00dcc4df03e39)