### PR TITLE
test: expand balancing trigger and x402 helper coverage

### DIFF
--- a/api_balancing/internal/handlers/x402_helpers_test.go
+++ b/api_balancing/internal/handlers/x402_helpers_test.go
@@ -34,7 +34,7 @@ func (s *stubX402Service) SettleX402Payment(ctx context.Context, req *pb.SettleX
 func setupPurserClient(t *testing.T, service *stubX402Service) (*purserclient.GRPCClient, func()) {
 	t.Helper()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}

--- a/api_balancing/internal/triggers/processor_test.go
+++ b/api_balancing/internal/triggers/processor_test.go
@@ -517,7 +517,7 @@ func newTestProcessor(t *testing.T) *Processor {
 func setupCommodoreClient(t *testing.T, response *pb.ValidateStreamKeyResponse, responseErr error) (*commodore.GRPCClient, func()) {
 	t.Helper()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatalf("failed to listen: %v", err)
 	}


### PR DESCRIPTION
### Motivation
- Increase unit-test coverage for api_balancing trigger handlers and the quick‑win `settleX402PaymentForPlayback` helper to catch regressions in billing enforcement and X402 response mappings.
- Exercise enforcement branches that reject streaming on suspended or negative‑balance tenants and add positive enrichment/cache tests for other trigger handlers.

### Description
- Added tests in `api_balancing/internal/triggers/processor_test.go` that introduce `stubCommodoreInternalService`, `setupCommodoreClient`, `newTestProcessor`, and tests covering cache enrichment for `handleProcessBilling`, `handleStorageLifecycleData`, `handleDVRLifecycleData`, the positive `handlePushRewrite` path, and rejecting branches for suspended and negative‑balance tenants, using `errors.As` to assert typed `ingesterrors.IngestError` values.
- Added tests in `api_balancing/internal/handlers/x402_helpers_test.go` that introduce `stubX402Service`, `setupPurserClient`, `validPaymentHeader`, and cover `settleX402PaymentForPlayback` success, invalid header, settlement failure, `RequiresBillingDetails`, and `IsAuthOnly` mappings.
- Small test helpers and signatures were adjusted (e.g. `setupCommodoreClient` param rename to `responseErr`) and test files were `gofmt`ed.

### Testing
- Ran `go test ./internal/triggers -run TestHandlePushRewrite_ -count=1 -v -timeout 30s` and all targeted trigger tests passed.
- Ran `go test ./internal/handlers -run TestSettleX402PaymentForPlayback_ -count=1 -v -timeout 30s` and all targeted x402 helper tests passed.
- Ran `make lint`; lint completed with warnings about the missing baseline revision in the sandbox git history but reported no new issues for the modified packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69893022ce488330a030e8ad1214e063)