### PR TITLE
Harden DLQ and service-event observability (preserve event_id/event_type, surface tenant drops)

### DIFF
--- a/pkg/kafka/dlq_test.go
+++ b/pkg/kafka/dlq_test.go
@@ -35,8 +35,14 @@ func TestEncodeDLQMessageExtractsTenantIDFromPayload(t *testing.T) {
 	if payload.TenantID != "tenant-123" {
 		t.Fatalf("expected tenant_id tenant-123, got %q", payload.TenantID)
 	}
+	if payload.EventID != "evt-1" {
+		t.Fatalf("expected event_id evt-1, got %q", payload.EventID)
+	}
 	if payload.Headers["tenant_id"] != "tenant-123" {
 		t.Fatalf("expected tenant_id header tenant-123, got %q", payload.Headers["tenant_id"])
+	}
+	if payload.Headers["event_id"] != "evt-1" {
+		t.Fatalf("expected event_id header evt-1, got %q", payload.Headers["event_id"])
 	}
 	if payload.Headers["event_type"] != "viewer_connect" {
 		t.Fatalf("expected event_type header viewer_connect, got %q", payload.Headers["event_type"])
@@ -79,7 +85,9 @@ func TestEncodeDLQMessageUsesHeaderTenantID(t *testing.T) {
 		Timestamp: time.Now(),
 		Value:     []byte("not-json"),
 		Headers: map[string]string{
-			"tenant_id": "tenant-999",
+			"tenant_id":  "tenant-999",
+			"event_id":   "evt-999",
+			"event_type": "stream_lifecycle_update",
 		},
 	}
 
@@ -95,6 +103,12 @@ func TestEncodeDLQMessageUsesHeaderTenantID(t *testing.T) {
 
 	if payload.TenantID != "tenant-999" {
 		t.Fatalf("expected tenant_id tenant-999, got %q", payload.TenantID)
+	}
+	if payload.EventID != "evt-999" {
+		t.Fatalf("expected event_id evt-999, got %q", payload.EventID)
+	}
+	if payload.EventType != "stream_lifecycle_update" {
+		t.Fatalf("expected event_type stream_lifecycle_update, got %q", payload.EventType)
 	}
 	if payload.Headers["tenant_id"] != "tenant-999" {
 		t.Fatalf("expected tenant_id header tenant-999, got %q", payload.Headers["tenant_id"])


### PR DESCRIPTION
### Motivation
- Improve federation incident triage by ensuring DLQ entries keep stable correlation keys (`tenant_id`, `event_id`, `event_type`) so replays and forensics can be tenant-scoped and actionable. (closing a high-signal blind spot in DLQ payloads).
- Make service-plane audit drops due to missing/invalid tenant identifiers observable to operators so these events are not silently lost and can be investigated with `ingest_errors` records.
- These changes target runbook readiness: clearer metrics/logs/rows for tenant-scoped failures and preserved identifiers across DLQ/replay paths.

### Description
- Preserve and expose event identity in DLQ payloads by adding `event_id` and `event_type` to `DLQPayload` and backfilling them from message headers or JSON value when missing; also copy recovered metadata into DLQ headers for downstream tooling (changes in `pkg/kafka/dlq.go` at payload and encode paths, see `DLQPayload` and `EncodeDLQMessage`). [pkg/kafka/dlq.go:11-23, pkg/kafka/dlq.go:27-67, pkg/kafka/dlq.go:109-136]
- Add a JSON metadata extractor `extractMessageMetadataFromJSON` to recover `tenant_id`, `event_id`, and `event_type` from message payloads when headers are incomplete. [pkg/kafka/dlq.go:103-136]
- Make service-event audit drops observable: when `tenant_id` is missing/invalid in `processServiceEventAudit`, write an `ingest_errors` record with reason `missing_or_invalid_tenant_id_service_event`, emit a warning with event identifiers, increment dropped metrics, and return `errDropped` so callers treat it as a deliberate drop path rather than silently ignoring. [api_analytics_ingest/internal/handlers/handlers.go:3219-3239]
- Tests updated/added: extend DLQ tests to assert `event_id` extraction and header propagation; add `TestHandleServiceEventMissingTenantIDWritesIngestError` to assert a missing-tenant service event creates an `ingest_errors` row and does not write `api_events`. [pkg/kafka/dlq_test.go:11-116, api_analytics_ingest/internal/handlers/handlers_test.go:781-809]

### Testing
- Ran unit tests for modified packages: `go test ./pkg/kafka` succeeded. (DLQ unit tests updated and passing.)
- Ran `go test ./api_analytics_ingest/internal/handlers` and targeted test runs (including `TestHandleServiceEventMissingTenantIDWritesIngestError`, `TestHandleAnalyticsEventMissingTenantIDWritesIngestError`, `TestHandleAnalyticsEventMalformedPayloadWritesIngestError`) which all passed.
- `make test` and `make lint` were not fully green in this environment due to toolchain gaps (missing `protoc-gen-go` when `make proto` ran earlier, and `golangci-lint` built with Go 1.24 while repo targets Go 1.25), which are environment/tooling issues rather than code regressions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d07eb7b108330b8632c083c76a548)