### PR TITLE
Harden mixed-version analytics compatibility for proto decoding and billing queries

### DIFF
--- a/api_analytics_ingest/internal/handlers/handlers.go
+++ b/api_analytics_ingest/internal/handlers/handlers.go
@@ -85,7 +85,9 @@ func (h *AnalyticsHandler) parseProtobufData(event kafka.AnalyticsEvent, target 
 
 	// Parse JSON using protojson to maintain proper protobuf semantics
 	unmarshaler := protojson.UnmarshalOptions{
-		DiscardUnknown: false,
+		// Mixed-version clusters may emit fields newer than this ingest binary.
+		// Discarding unknown fields keeps ingestion forward-compatible.
+		DiscardUnknown: true,
 	}
 
 	return unmarshaler.Unmarshal(jsonData, target)

--- a/api_analytics_query/internal/handlers/billing_test.go
+++ b/api_analytics_query/internal/handlers/billing_test.go
@@ -1,8 +1,15 @@
 package handlers
 
 import (
+	"context"
+	"fmt"
 	"math"
 	"testing"
+	"time"
+
+	"frameworks/pkg/logging"
+
+	"github.com/DATA-DOG/go-sqlmock"
 )
 
 func TestSanitizeFloat(t *testing.T) {
@@ -55,5 +62,66 @@ func TestAttributedViewerClusterID(t *testing.T) {
 				t.Fatalf("expected %q, got %q", test.expected, actual)
 			}
 		})
+	}
+}
+
+func TestMissingColumnCompatibilityError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "unknown expression", err: fmt.Errorf("Code: 47, Unknown expression identifier origin_cluster_id"), want: true},
+		{name: "missing columns", err: fmt.Errorf("Code: 47, Missing columns: 'cluster_id'"), want: true},
+		{name: "other error", err: fmt.Errorf("connection refused"), want: false},
+		{name: "nil", err: nil, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMissingColumnCompatibilityError(tt.err); got != tt.want {
+				t.Fatalf("isMissingColumnCompatibilityError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestQueryTenantViewerMetricsFallsBackForLegacySchema(t *testing.T) {
+	db, mock, err := sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+	if err != nil {
+		t.Fatalf("sqlmock.New: %v", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	bs := &BillingSummarizer{clickhouse: db, logger: logging.NewLogger()}
+	start := time.Unix(1700000000, 0).UTC()
+	end := start.Add(time.Hour)
+
+	mock.ExpectQuery(`SELECT\s+cluster_id,\s+origin_cluster_id`).
+		WithArgs("tenant-1", start, end).
+		WillReturnError(fmt.Errorf("Code: 47, Unknown expression identifier `origin_cluster_id`"))
+
+	rows := sqlmock.NewRows([]string{"cluster_id", "egress_gb", "viewer_hours", "unique_viewers"}).
+		AddRow("cluster-a", 12.5, 3.0, 42)
+	mock.ExpectQuery(`SELECT\s+cluster_id,\s+COALESCE\(sum\(egress_gb\), 0\) as egress_gb`).
+		WithArgs("tenant-1", start, end).
+		WillReturnRows(rows)
+
+	got, err := bs.queryTenantViewerMetrics(context.Background(), "tenant-1", start, end)
+	if err != nil {
+		t.Fatalf("queryTenantViewerMetrics error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(got))
+	}
+	if got[0].ClusterID != "cluster-a" || got[0].OriginClusterID != "" {
+		t.Fatalf("unexpected cluster attribution row: %#v", got[0])
+	}
+	if got[0].EgressGB != 12.5 || got[0].ViewerHours != 3.0 || got[0].UniqueViewers != 42 {
+		t.Fatalf("unexpected metric values: %#v", got[0])
+	}
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("sql expectations: %v", err)
 	}
 }


### PR DESCRIPTION
### Motivation
- Prevent ingestion failures when newer producers emit unknown protobuf JSON fields during rolling upgrades by making decode forward-compatible. 
- Avoid usage-summarization outages during ClickHouse schema migrations where `tenant_viewer_daily` may lack `origin_cluster_id` on some nodes. 
- Add regression coverage to ensure mixed-version decode/fallback behavior is preserved.

### Description
- Make protobuf JSON unmarshaling forward-compatible by enabling unknown-field discard in `parseProtobufData` (`api_analytics_ingest/internal/handlers/handlers.go` around lines 78-94) so newer fields do not cause hard failures. 
- Add an ingest unit test that verifies unknown fields are ignored while malformed payloads still error (`api_analytics_ingest/internal/handlers/handlers_test.go` around lines 723-752). 
- Introduce `queryTenantViewerMetrics` with a three-stage ClickHouse query fallback (preferred: `cluster_id, origin_cluster_id`; fallback: `cluster_id`; final fallback: tenant-level aggregate) and a classifier for missing-column compatibility errors, then wire it into billing aggregation (`api_analytics_query/internal/handlers/billing.go` additions at ~L207 and new helper at ~L453-L559). 
- Add billing unit tests that validate the missing-column detection and the fallback query behavior (`api_analytics_query/internal/handlers/billing_test.go` additions starting near top and new test at ~L89-L127).

### Testing
- Ran the focused ingest decode regression: `cd api_analytics_ingest && go test ./internal/handlers -run TestParseProtobufData -count=1`, which passed and demonstrates unknown-field discard behavior. 
- Ran the billing compatibility tests: `cd api_analytics_query && go test ./internal/handlers -run 'Test(MissingColumnCompatibilityError|QueryTenantViewerMetricsFallsBackForLegacySchema|AttributedViewerClusterID|SanitizeFloat)' -count=1`, which passed and proves the ClickHouse fallback path. 
- Note: a full `api_analytics_ingest` package test run showed a pre-existing/unrelated failing test (`TestHandleAnalyticsEventMalformedPayloadWritesIngestError`), so I validated the compatibility changes with focused test runs listed above rather than the full package run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d07e46f8c83308cc0de3cfcb5c79d)