### PR TITLE
Harden DNS reconciliation cleanup and Cloudflare idempotent retry behavior

### DIFF
--- a/api_dns/internal/logic/dns.go
+++ b/api_dns/internal/logic/dns.go
@@ -219,7 +219,7 @@ func (m *DNSManager) SyncServiceByCluster(ctx context.Context, serviceType strin
 		prefix := "edge-"
 		suffix := "." + rootDomain
 		for _, rec := range aRecords {
-			if !strings.HasPrefix(rec.Name, prefix) || !strings.HasSuffix(rec.Name, suffix) {
+			if !isEdgeNodeRecord(rec.Name, prefix, suffix) {
 				continue
 			}
 			if _, keep := desiredNodeRecords[rec.Name]; keep {
@@ -235,6 +235,23 @@ func (m *DNSManager) SyncServiceByCluster(ctx context.Context, serviceType strin
 		return nil, nil
 	}
 	return partialErrors, nil
+}
+
+func isEdgeNodeRecord(recordName, prefix, suffix string) bool {
+	if !strings.HasPrefix(recordName, prefix) || !strings.HasSuffix(recordName, suffix) {
+		return false
+	}
+
+	label := strings.TrimSuffix(recordName, suffix)
+	if strings.Contains(label, ".") {
+		return false
+	}
+
+	if label == "edge-egress" {
+		return false
+	}
+
+	return true
 }
 
 func (m *DNSManager) clusterServiceFQDN(serviceType, rootDomain string) string {

--- a/api_dns/internal/provider/cloudflare/client.go
+++ b/api_dns/internal/provider/cloudflare/client.go
@@ -81,7 +81,7 @@ func (c *Client) doRequest(method, path string, body interface{}) (*APIResponse,
 	}
 
 	executor := c.executor
-	if method != http.MethodGet && method != http.MethodHead && method != http.MethodDelete {
+	if method == http.MethodPost || method == http.MethodPatch {
 		cfg := clients.DefaultHTTPExecutorConfig()
 		cfg.MaxRetries = 0
 		executor = clients.NewHTTPExecutor(cfg) //nolint:bodyclose


### PR DESCRIPTION
### Motivation
- Prevent accidental deletion of live cluster service records during per-cluster `edge-egress` cleanup which caused drift under partial failures. (observed in cluster-scoped cleanup matching logic)
- Restore retry behavior for idempotent provider updates so transient Cloudflare errors do not permanently break reconciliation. 
- Add regression tests to lock in the intended behaviors and reduce future regressions.

### Description
- Tighten edge-node record classification so per-cluster cleanup only deletes node-scoped records `edge-<node>.<cluster>.<domain>` and will never match the service record `edge-egress.<cluster>.<domain>`, by adding `isEdgeNodeRecord` and using it in the cleanup loop (changes in `api_dns/internal/logic/dns.go`, see logic near `SyncServiceByCluster` and the new helper at ~L214-L255). (files changed: `api_dns/internal/logic/dns.go`)
- Adjust Cloudflare client retry policy to disable retries only for non-idempotent `POST`/`PATCH` while allowing retries for idempotent `PUT` updates used by reconciliation (change in `api_dns/internal/provider/cloudflare/client.go` near ~L83-L92). (file changed: `api_dns/internal/provider/cloudflare/client.go`)
- Add unit tests that cover the new node-record classification and the cluster cleanup behavior (`TestSyncServiceByCluster_EdgeEgressCleanupSkipsServiceRecord` and `TestIsEdgeNodeRecord`) in `api_dns/internal/logic/dns_test.go` (tests added around ~L401-L475). (file changed: `api_dns/internal/logic/dns_test.go`)
- Add provider-level test ensuring idempotent `PUT` requests are retried on transient 429/RateLimit responses (`TestClient_RetriesIdempotentPutRequests`) in `api_dns/internal/provider/cloudflare/client_test.go` (test added around ~L79-L116). (file changed: `api_dns/internal/provider/cloudflare/client_test.go`)
- Notes on observed control flow: Quartermaster triggers async DNS sync via `navigatorClient.SyncDNS(...)` (best-effort, non-blocking) at `api_tenants/internal/grpc/server.go` ~L3301-L3323, and Navigator exposes `SyncDNS` and runs periodic reconciler workers in `api_dns/cmd/navigator/main.go` ~L108-L125 and `~L216-L238` which is relevant to eventual consistency and residual risk.

### Testing
- Ran `make fmt` successfully across modules and ensured formatting sanity. (result: success)
- Ran unit tests for the affected packages with `cd api_dns && go test ./internal/logic ./internal/provider/cloudflare` and all tests passed including the new regressions. (result: `ok` for both packages)
- Attempted `make lint` but it failed in this environment due to `golangci-lint` being built with an older Go runtime than the repo target (environment mismatch), so lint checks were not completed here; this is an environment issue, not a code regression. (result: lint run failed due to Go toolchain mismatch)
- Tests added: `TestSyncServiceByCluster_EdgeEgressCleanupSkipsServiceRecord`, `TestIsEdgeNodeRecord`, and `TestClient_RetriesIdempotentPutRequests`, and they pass locally in this run.

Files touched (high-level): `api_dns/internal/logic/dns.go`, `api_dns/internal/logic/dns_test.go`, `api_dns/internal/provider/cloudflare/client.go`, `api_dns/internal/provider/cloudflare/client_test.go`, and supporting formatting updates.

Residual risk: the Quartermaster-triggered `SyncDNS` path remains asynchronous and best-effort (failures are logged and rely on the periodic reconciler for recovery), so short windows of drift can still occur until the next reconcile tick; mitigations implemented reduce the risk of destructive cleanup and improve recovery on provider blips.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d113b8dd08330a00ff0fb834c2617)