### PR TITLE
Fix federation reconciliation cleanup and destination-node validation

### DIFF
--- a/api_balancing/internal/federation/peer_manager.go
+++ b/api_balancing/internal/federation/peer_manager.go
@@ -1307,6 +1307,12 @@ func (pm *PeerManager) checkReplicationCompletion() {
 			continue
 		}
 
+		instances := sm.GetStreamInstances(record.StreamName)
+		destInstance, ok := instances[record.DestNodeID]
+		if !ok || destInstance.Status != "live" {
+			continue
+		}
+
 		_ = pm.cache.DeleteActiveReplication(ctx, record.StreamName)
 		pm.broadcastToPeers(&pb.PeerMessage{
 			ClusterId: pm.clusterID,


### PR DESCRIPTION
### Motivation
- Prevent stale cross-cluster routing and premature convergence after restarts or reassignment by ensuring stream-ad withdrawals clean up reverse indexes and by tightening replication completion checks (addresses remote playback_id leakage and wrong-node acking). 【F: api_balancing/internal/federation/cache.go L511-L536】【F: api_balancing/internal/federation/peer_manager.go L1231-L1277】

### Description
- Clear playback-index on stream-ad withdrawal and make the withdraw atomic, and if the withdraw payload omits `playback_id` recover it from the stored ad before deletion to avoid leaving stale reverse mappings (changes in `SetStreamAd`). 【F: api_balancing/internal/federation/cache.go L511-L536】【F: api_balancing/internal/federation/cache.go L561-L573】
- Add `DeletePlaybackIndex(ctx, playbackID)` helper to perform immediate removal of a playback reverse mapping. 【F: api_balancing/internal/federation/cache.go L567-L573】
- Require the active replication record's recorded destination node to be live before clearing the in-flight `ActiveReplication` and broadcasting availability (tighten `checkReplicationCompletion`). 【F: api_balancing/internal/federation/peer_manager.go L1231-L1277】
- Add regression tests covering playback-index cleanup on withdraw (including withdraws missing `playback_id`) and replication completion semantics tied to the destination node. 【F: api_balancing/internal/federation/cache_test.go L625-L693】【F: api_balancing/internal/federation/peer_manager_test.go L348-L418】

### Testing
- Ran package unit tests: `cd api_balancing && go test ./internal/federation -count=1`, which passed (federation package tests succeeded).
- Added and executed tests: `TestStreamAd_WithdrawClearsPlaybackIndex`, `TestStreamAd_WithdrawWithoutPlaybackIDStillClearsExistingIndex`, `TestCheckReplicationCompletion_RequiresDestinationNodeLive`, and `TestCheckReplicationCompletion_ClearsRecordWhenDestinationNodeLive`, all exercising the modified behavior and preventing regressions.
- Full repository `make test` was not run here because root test targets invoke GraphQL codegen (`gqlgen`) and proto generation; `make lint` also failed in this environment due to a Go/tooling version mismatch, so those checks are environment-blocked but orthogonal to the functional fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d14bf2308833084a29fcd8daf45f8)