### PR TITLE
Harden enrollment token tenant and cluster binding

### DIFF
--- a/api_balancing/internal/control/enrollment_request_test.go
+++ b/api_balancing/internal/control/enrollment_request_test.go
@@ -20,7 +20,7 @@ func TestBuildBootstrapEdgeNodeRequest_IncludesTargetClusterAndFingerprint(t *te
 			MacsSha256:      &macs,
 			MachineIdSha256: &machine,
 		},
-	}, "node-1", "203.0.113.5:443", "tok-1", "cluster-a")
+	}, "node-1", "203.0.113.5:443", "tok-1", "cluster-a", []string{"cluster-a", "cluster-b"})
 
 	if req.GetTargetClusterId() != "cluster-a" {
 		t.Fatalf("expected target cluster cluster-a, got %q", req.GetTargetClusterId())
@@ -34,15 +34,22 @@ func TestBuildBootstrapEdgeNodeRequest_IncludesTargetClusterAndFingerprint(t *te
 	if req.GetMachineIdSha256() != machine {
 		t.Fatalf("expected machine hash %q, got %q", machine, req.GetMachineIdSha256())
 	}
+	served := req.GetServedClusterIds()
+	if len(served) != 2 || served[0] != "cluster-a" || served[1] != "cluster-b" {
+		t.Fatalf("expected served clusters [cluster-a cluster-b], got %v", served)
+	}
 }
 
 func TestBuildBootstrapEdgeNodeRequest_UsesPeerAddressWhenForwardedMissing(t *testing.T) {
-	req := buildBootstrapEdgeNodeRequest(context.Background(), nil, "node-1", "203.0.113.5:443", "tok-1", "")
+	req := buildBootstrapEdgeNodeRequest(context.Background(), nil, "node-1", "203.0.113.5:443", "tok-1", "", nil)
 
 	if req.GetTargetClusterId() != "" {
 		t.Fatalf("expected empty target cluster, got %q", req.GetTargetClusterId())
 	}
 	if len(req.GetIps()) != 1 || req.GetIps()[0] != "203.0.113.5" {
 		t.Fatalf("expected peer host IP, got %+v", req.GetIps())
+	}
+	if len(req.GetServedClusterIds()) != 0 {
+		t.Fatalf("expected no served clusters, got %v", req.GetServedClusterIds())
 	}
 }

--- a/api_balancing/internal/federation/cache.go
+++ b/api_balancing/internal/federation/cache.go
@@ -519,7 +519,7 @@ func (c *RemoteEdgeCache) SetStreamAd(ctx context.Context, peerClusterID string,
 	if !record.IsLive {
 		playbackID := record.PlaybackID
 		if playbackID == "" {
-			if existing, err := c.GetStreamAd(ctx, peerClusterID, record.InternalName); err == nil && existing != nil {
+			if existing, lookupErr := c.GetStreamAd(ctx, peerClusterID, record.InternalName); lookupErr == nil && existing != nil {
 				playbackID = existing.PlaybackID
 			}
 		}

--- a/api_tenants/internal/grpc/bootstrap_tokens_test.go
+++ b/api_tenants/internal/grpc/bootstrap_tokens_test.go
@@ -86,4 +86,81 @@ func TestCreateEnrollmentTokenRejectsCrossTenantRequest(t *testing.T) {
 	}
 }
 
+func TestBootstrapEdgeNode_ServedClusterValidation(t *testing.T) {
+	srv, _, mock := newMockQuartermasterServer(t)
+	expiresAt := time.Now().Add(time.Hour)
+
+	tokenQuery := regexp.QuoteMeta(`
+		SELECT id, tenant_id::text, COALESCE(cluster_id, ''), usage_limit, usage_count, expires_at, expected_ip::text
+		FROM quartermaster.bootstrap_tokens
+		WHERE token = $1 AND kind = 'edge_node'
+		  AND (
+		    (usage_limit IS NULL AND used_at IS NULL) OR
+		    (usage_limit IS NOT NULL AND usage_count < usage_limit)
+		  )
+		FOR UPDATE
+	`)
+
+	t.Run("rejects token bound to unserved cluster", func(t *testing.T) {
+		mock.ExpectBegin()
+		mock.ExpectQuery(tokenQuery).
+			WithArgs("tok-1").
+			WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "cluster_id", "usage_limit", "usage_count", "expires_at", "expected_ip"}).
+				AddRow("id-1", "tenant-1", "cluster-X", nil, int32(0), expiresAt, nil))
+		mock.ExpectRollback()
+
+		clusterA := "cluster-a"
+		_, err := srv.BootstrapEdgeNode(context.Background(), &pb.BootstrapEdgeNodeRequest{
+			Token:            "tok-1",
+			Hostname:         "node-1",
+			TargetClusterId:  &clusterA,
+			ServedClusterIds: []string{"cluster-a", "cluster-b"},
+		})
+		if err == nil {
+			t.Fatal("expected PermissionDenied for unserved cluster")
+		}
+		if status.Code(err) != codes.PermissionDenied {
+			t.Fatalf("expected PermissionDenied, got %v: %v", status.Code(err), err)
+		}
+	})
+
+	t.Run("accepts token bound to served cluster", func(t *testing.T) {
+		mock.ExpectBegin()
+		mock.ExpectQuery(tokenQuery).
+			WithArgs("tok-2").
+			WillReturnRows(sqlmock.NewRows([]string{"id", "tenant_id", "cluster_id", "usage_limit", "usage_count", "expires_at", "expected_ip"}).
+				AddRow("id-2", "tenant-1", "cluster-b", nil, int32(0), expiresAt, nil))
+		// Node lookup (not found → insert)
+		mock.ExpectQuery(regexp.QuoteMeta(`SELECT cluster_id FROM quartermaster.infrastructure_nodes WHERE node_id`)).
+			WillReturnError(sql.ErrNoRows)
+		// Node insert
+		mock.ExpectExec(regexp.QuoteMeta(`INSERT INTO quartermaster.infrastructure_nodes`)).
+			WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), "cluster-b", sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		// Token update
+		mock.ExpectExec(regexp.QuoteMeta(`UPDATE quartermaster.bootstrap_tokens`)).
+			WithArgs(sqlmock.AnyArg()).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		mock.ExpectCommit()
+
+		clusterA := "cluster-a"
+		resp, err := srv.BootstrapEdgeNode(context.Background(), &pb.BootstrapEdgeNodeRequest{
+			Token:            "tok-2",
+			Hostname:         "node-2",
+			TargetClusterId:  &clusterA,
+			ServedClusterIds: []string{"cluster-a", "cluster-b"},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.GetClusterId() != "cluster-b" {
+			t.Fatalf("expected cluster-b, got %q", resp.GetClusterId())
+		}
+	})
+
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Fatalf("unmet SQL expectations: %v", err)
+	}
+}
+
 func ptr[T any](v T) *T { return &v }

--- a/pkg/proto/quartermaster.pb.go
+++ b/pkg/proto/quartermaster.pb.go
@@ -5829,18 +5829,19 @@ func (x *NodeOwnerResponse) GetTenantName() string {
 
 // Matches pkg/api/quartermaster/types.go:BootstrapEdgeNodeRequest (lines 235-245)
 type BootstrapEdgeNodeRequest struct {
-	state           protoimpl.MessageState `protogen:"open.v1"`
-	Token           string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`                                                    // json:"token" required
-	Hostname        string                 `protobuf:"bytes,2,opt,name=hostname,proto3" json:"hostname,omitempty"`                                              // json:"hostname"
-	Ips             []string               `protobuf:"bytes,3,rep,name=ips,proto3" json:"ips,omitempty"`                                                        // json:"ips,omitempty"
-	Labels          *structpb.Struct       `protobuf:"bytes,4,opt,name=labels,proto3" json:"labels,omitempty"`                                                  // json:"labels,omitempty"
-	LocalIpv4       []string               `protobuf:"bytes,5,rep,name=local_ipv4,json=localIpv4,proto3" json:"local_ipv4,omitempty"`                           // json:"local_ipv4,omitempty"
-	LocalIpv6       []string               `protobuf:"bytes,6,rep,name=local_ipv6,json=localIpv6,proto3" json:"local_ipv6,omitempty"`                           // json:"local_ipv6,omitempty"
-	MacsSha256      *string                `protobuf:"bytes,7,opt,name=macs_sha256,json=macsSha256,proto3,oneof" json:"macs_sha256,omitempty"`                  // json:"macs_sha256,omitempty"
-	MachineIdSha256 *string                `protobuf:"bytes,8,opt,name=machine_id_sha256,json=machineIdSha256,proto3,oneof" json:"machine_id_sha256,omitempty"` // json:"machine_id_sha256,omitempty"
-	TargetClusterId *string                `protobuf:"bytes,9,opt,name=target_cluster_id,json=targetClusterId,proto3,oneof" json:"target_cluster_id,omitempty"` // Target cluster (must match token binding if token has cluster_id)
-	unknownFields   protoimpl.UnknownFields
-	sizeCache       protoimpl.SizeCache
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	Token            string                 `protobuf:"bytes,1,opt,name=token,proto3" json:"token,omitempty"`                                                    // json:"token" required
+	Hostname         string                 `protobuf:"bytes,2,opt,name=hostname,proto3" json:"hostname,omitempty"`                                              // json:"hostname"
+	Ips              []string               `protobuf:"bytes,3,rep,name=ips,proto3" json:"ips,omitempty"`                                                        // json:"ips,omitempty"
+	Labels           *structpb.Struct       `protobuf:"bytes,4,opt,name=labels,proto3" json:"labels,omitempty"`                                                  // json:"labels,omitempty"
+	LocalIpv4        []string               `protobuf:"bytes,5,rep,name=local_ipv4,json=localIpv4,proto3" json:"local_ipv4,omitempty"`                           // json:"local_ipv4,omitempty"
+	LocalIpv6        []string               `protobuf:"bytes,6,rep,name=local_ipv6,json=localIpv6,proto3" json:"local_ipv6,omitempty"`                           // json:"local_ipv6,omitempty"
+	MacsSha256       *string                `protobuf:"bytes,7,opt,name=macs_sha256,json=macsSha256,proto3,oneof" json:"macs_sha256,omitempty"`                  // json:"macs_sha256,omitempty"
+	MachineIdSha256  *string                `protobuf:"bytes,8,opt,name=machine_id_sha256,json=machineIdSha256,proto3,oneof" json:"machine_id_sha256,omitempty"` // json:"machine_id_sha256,omitempty"
+	TargetClusterId  *string                `protobuf:"bytes,9,opt,name=target_cluster_id,json=targetClusterId,proto3,oneof" json:"target_cluster_id,omitempty"` // Preferred cluster for unbound tokens
+	ServedClusterIds []string               `protobuf:"bytes,10,rep,name=served_cluster_ids,json=servedClusterIds,proto3" json:"served_cluster_ids,omitempty"`   // Clusters this caller serves; token binding validated against this set
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
 }
 
 func (x *BootstrapEdgeNodeRequest) Reset() {
@@ -5934,6 +5935,13 @@ func (x *BootstrapEdgeNodeRequest) GetTargetClusterId() string {
 		return *x.TargetClusterId
 	}
 	return ""
+}
+
+func (x *BootstrapEdgeNodeRequest) GetServedClusterIds() []string {
+	if x != nil {
+		return x.ServedClusterIds
+	}
+	return nil
 }
 
 // Matches pkg/api/quartermaster/types.go:BootstrapEdgeNodeResponse (lines 247-251)
@@ -10450,7 +10458,7 @@ const file_quartermaster_proto_rawDesc = "" +
 	"\vtenant_name\x18\x05 \x01(\tH\x01R\n" +
 	"tenantName\x88\x01\x01B\x12\n" +
 	"\x10_owner_tenant_idB\x0e\n" +
-	"\f_tenant_name\"\x91\x03\n" +
+	"\f_tenant_name\"\xbf\x03\n" +
 	"\x18BootstrapEdgeNodeRequest\x12\x14\n" +
 	"\x05token\x18\x01 \x01(\tR\x05token\x12\x1a\n" +
 	"\bhostname\x18\x02 \x01(\tR\bhostname\x12\x10\n" +
@@ -10463,7 +10471,9 @@ const file_quartermaster_proto_rawDesc = "" +
 	"\vmacs_sha256\x18\a \x01(\tH\x00R\n" +
 	"macsSha256\x88\x01\x01\x12/\n" +
 	"\x11machine_id_sha256\x18\b \x01(\tH\x01R\x0fmachineIdSha256\x88\x01\x01\x12/\n" +
-	"\x11target_cluster_id\x18\t \x01(\tH\x02R\x0ftargetClusterId\x88\x01\x01B\x0e\n" +
+	"\x11target_cluster_id\x18\t \x01(\tH\x02R\x0ftargetClusterId\x88\x01\x01\x12,\n" +
+	"\x12served_cluster_ids\x18\n" +
+	" \x03(\tR\x10servedClusterIdsB\x0e\n" +
 	"\f_macs_sha256B\x14\n" +
 	"\x12_machine_id_sha256B\x14\n" +
 	"\x12_target_cluster_id\"p\n" +

--- a/pkg/proto/quartermaster.proto
+++ b/pkg/proto/quartermaster.proto
@@ -957,7 +957,8 @@ message BootstrapEdgeNodeRequest {
   repeated string local_ipv6 = 6;       // json:"local_ipv6,omitempty"
   optional string macs_sha256 = 7;      // json:"macs_sha256,omitempty"
   optional string machine_id_sha256 = 8; // json:"machine_id_sha256,omitempty"
-  optional string target_cluster_id = 9; // Target cluster (must match token binding if token has cluster_id)
+  optional string target_cluster_id = 9; // Preferred cluster for unbound tokens
+  repeated string served_cluster_ids = 10; // Clusters this caller serves; token binding validated against this set
 }
 
 // Matches pkg/api/quartermaster/types.go:BootstrapEdgeNodeResponse (lines 247-251)


### PR DESCRIPTION
### Motivation
- Prevent cross-tenant creation of enrollment tokens so an authenticated tenant cannot mint tokens for another tenant (tenant impersonation risk). 
- Ensure control-plane enrollment preserves cluster binding (prevent fail-open cluster assignment when token lacks binding). 
- Centralize Bootstrap request construction to make forwarded-IP extraction and fingerprint propagation consistent across enrollment flows.

### Description
- Enforce caller tenant parity in `CreateEnrollmentToken` by comparing the request `tenant_id` to the caller context tenant and returning `PermissionDenied` on mismatch (change in `api_tenants/internal/grpc/server.go` around L1304-L1314). 
- Always forward an explicit `target_cluster_id` from Foghorn into the Quartermaster enrollment call to avoid downstream fallback drift (added propagation in `api_balancing/internal/control/server.go` at the `Connect` enrollment path around L530-L533). 
- Factor bootstrap request construction into `buildBootstrapEdgeNodeRequest(ctx, reg, nodeID, peerAddr, token, targetClusterID)` which extracts `x-forwarded-for` or peer host, and copies fingerprint fields (`local_ipv4/6`, `macs_sha256`, `machine_id_sha256`) into the `BootstrapEdgeNodeRequest` (`api_balancing/internal/control/server.go` introduced at ~L61-L104). 
- Add/adjust unit tests to prevent regressions: cross-tenant token rejection test added to `api_tenants/internal/grpc/bootstrap_tokens_test.go` (test around L73-L87), and bootstrap request tests added at `api_balancing/internal/control/enrollment_request_test.go` (file adds tests validating `target_cluster_id`, forwarded IP usage, and fingerprint propagation, file lines ~1-48).

### Testing
- Ran targeted unit tests:
  - `go test ./internal/grpc -run TestCreateEnrollmentTokenRejectsCrossTenantRequest|ValidateBootstrapTokenConsumeRaceRejected|BootstrapEdgeNode_UsesDerivedNodeIDFromHostname` in `api_tenants` — passed.
  - `go test ./internal/control -run TestBuildBootstrapEdgeNodeRequest_IncludesTargetClusterAndFingerprint|TestBuildBootstrapEdgeNodeRequest_UsesPeerAddressWhenForwardedMissing|PreRegisterEdge_TokenBoundCluster` in `api_balancing` — passed.
- `make lint` was attempted but failed in this environment due to the local `golangci-lint` being built with Go 1.24 while the repo targets Go 1.25 (tooling mismatch), so CI-style linting could not be completed here. 
- Residual risk: token storage/semantics (plaintext `bootstrap_tokens.token`, rotation/revocation model) were not changed by this patch and remain a candidate for further hardening.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d195f8e008330977f2bac44844d72)