### PR TITLE
Harden federation RPC auth and tenant isolation checks

### DIFF
--- a/api_balancing/internal/federation/server_auth_test.go
+++ b/api_balancing/internal/federation/server_auth_test.go
@@ -1,0 +1,140 @@
+package federation
+
+import (
+	"context"
+	"io"
+	"testing"
+
+	"frameworks/api_balancing/internal/state"
+	"frameworks/pkg/ctxkeys"
+	pb "frameworks/pkg/proto"
+
+	"github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
+)
+
+func newFederationTestLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetOutput(io.Discard)
+	return l
+}
+
+func serviceAuthContext() context.Context {
+	return context.WithValue(context.Background(), ctxkeys.KeyAuthType, "service")
+}
+
+func TestQueryStream_RequiresServiceAuthAndTenant(t *testing.T) {
+	srv := NewFederationServer(FederationServerConfig{Logger: newFederationTestLogger(), ClusterID: "cluster-a"})
+
+	_, err := srv.QueryStream(context.Background(), &pb.QueryStreamRequest{
+		StreamName:        "stream-1",
+		RequestingCluster: "cluster-b",
+		TenantId:          "tenant-a",
+	})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied for non-service auth, got %v", err)
+	}
+
+	_, err = srv.QueryStream(serviceAuthContext(), &pb.QueryStreamRequest{
+		StreamName:        "stream-1",
+		RequestingCluster: "cluster-b",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument when tenant missing, got %v", err)
+	}
+}
+
+func TestNotifyOriginPull_RejectsTenantMismatch(t *testing.T) {
+	sm := state.ResetDefaultManagerForTests()
+	t.Cleanup(sm.Shutdown)
+
+	nodeID := "node-1"
+	streamName := "stream-1"
+	tenantID := "tenant-a"
+
+	sm.SetNodeInfo(nodeID, nodeID, true, nil, nil, "", "", nil)
+	if err := sm.UpdateStreamFromBuffer(streamName, streamName, nodeID, tenantID, "READY", ""); err != nil {
+		t.Fatalf("UpdateStreamFromBuffer: %v", err)
+	}
+
+	srv := NewFederationServer(FederationServerConfig{Logger: newFederationTestLogger(), ClusterID: "cluster-a"})
+	resp, err := srv.NotifyOriginPull(serviceAuthContext(), &pb.OriginPullNotification{
+		StreamName:    streamName,
+		SourceNodeId:  nodeID,
+		DestClusterId: "cluster-b",
+		DestNodeId:    "dest-node",
+		TenantId:      "tenant-b",
+	})
+	if err != nil {
+		t.Fatalf("NotifyOriginPull returned error: %v", err)
+	}
+	if resp.GetAccepted() {
+		t.Fatalf("expected pull to be rejected for tenant mismatch")
+	}
+}
+
+type mockPeerChannelStream struct {
+	ctx  context.Context
+	msgs []*pb.PeerMessage
+	idx  int
+}
+
+func (m *mockPeerChannelStream) Context() context.Context     { return m.ctx }
+func (m *mockPeerChannelStream) SetHeader(metadata.MD) error  { return nil }
+func (m *mockPeerChannelStream) SendHeader(metadata.MD) error { return nil }
+func (m *mockPeerChannelStream) SetTrailer(metadata.MD)       {}
+func (m *mockPeerChannelStream) Send(*pb.PeerMessage) error   { return nil }
+func (m *mockPeerChannelStream) SendMsg(any) error            { return nil }
+func (m *mockPeerChannelStream) RecvMsg(any) error            { return nil }
+
+func (m *mockPeerChannelStream) Recv() (*pb.PeerMessage, error) {
+	if m.idx >= len(m.msgs) {
+		return nil, io.EOF
+	}
+	msg := m.msgs[m.idx]
+	m.idx++
+	return msg, nil
+}
+
+func TestPeerChannel_RejectsClusterIDMismatch(t *testing.T) {
+	cache, _ := setupTestCache(t)
+	srv := NewFederationServer(FederationServerConfig{Logger: newFederationTestLogger(), ClusterID: "cluster-a", Cache: cache})
+	stream := &mockPeerChannelStream{
+		ctx: serviceAuthContext(),
+		msgs: []*pb.PeerMessage{
+			{ClusterId: "cluster-b", Payload: &pb.PeerMessage_PeerHeartbeat{PeerHeartbeat: &pb.PeerHeartbeat{}}},
+			{ClusterId: "cluster-c", Payload: &pb.PeerMessage_PeerHeartbeat{PeerHeartbeat: &pb.PeerHeartbeat{}}},
+		},
+	}
+
+	err := srv.PeerChannel(stream)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied on cluster mismatch, got %v", err)
+	}
+}
+
+func TestPeerChannel_RequiresInitialClusterID(t *testing.T) {
+	srv := NewFederationServer(FederationServerConfig{Logger: newFederationTestLogger(), ClusterID: "cluster-a"})
+	stream := &mockPeerChannelStream{
+		ctx: serviceAuthContext(),
+		msgs: []*pb.PeerMessage{
+			{ClusterId: "", Payload: &pb.PeerMessage_PeerHeartbeat{PeerHeartbeat: &pb.PeerHeartbeat{}}},
+		},
+	}
+
+	err := srv.PeerChannel(stream)
+	if status.Code(err) != codes.InvalidArgument {
+		t.Fatalf("expected invalid argument for missing initial cluster id, got %v", err)
+	}
+}
+
+func TestPeerChannel_RejectsNonServiceAuth(t *testing.T) {
+	srv := NewFederationServer(FederationServerConfig{Logger: newFederationTestLogger(), ClusterID: "cluster-a"})
+	stream := &mockPeerChannelStream{ctx: context.Background()}
+	err := srv.PeerChannel(stream)
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v", err)
+	}
+}


### PR DESCRIPTION
### Motivation
- Close an authn/authz gap where federation RPCs could be invoked without explicit service-to-service identity, and enforce tenant-scoped access on cross-cluster paths. 
- Prevent cross-tenant origin-pull and artifact access when malformed or incomplete requests omit tenant or cluster identity. 
- Reduce identity-drift/spoofing risk on long-lived PeerChannel streams by pinning and validating the peer cluster identity.

### Description
- Enforce service-only access at federation RPC entrypoints by adding `requireFederationServiceAuth(ctx)` checks to `QueryStream`, `NotifyOriginPull`, `PrepareArtifact`, and `PeerChannel` (api_balancing/internal/federation/server.go). Relevant changes: `QueryStream` early auth + required `requesting_cluster`/`tenant_id` validation (server.go ~L101-L113, ~L108-L116), `NotifyOriginPull` requires `tenant_id` and applies LB tenant-scoping (server.go ~L200-L227, ~L243-L257), `PrepareArtifact` requires service auth and `tenant_id` (server.go ~L306-L320), and `PeerChannel` validates service auth and pins first `cluster_id` (server.go ~L560-L594).
- Tighten tenant-scoped load-balancer usage: LB selection for origin-pull now runs with `ctxkeys.KeyClusterScope` set to the requested tenant (server.go ~L223-L227), and post-lookup we reject pulls when the local stream's tenant does not match the request (server.go ~L252-L257).
- Harden PeerChannel identity handling: pin `peerClusterID` from the first message, reject missing initial `cluster_id` or later messages that change the cluster, and use the pinned channel identity when attributing cached replication / stream advertisement records (server.go ~L584-L594, ~L649-L656, ~L768-L776).
- Add helper `requireFederationServiceAuth` to centralize the service-auth requirement (server.go ~L940-L945).
- Add focused regression tests exercising the new boundaries in `api_balancing/internal/federation/server_auth_test.go`, including `TestQueryStream_RequiresServiceAuthAndTenant`, `TestNotifyOriginPull_RejectsTenantMismatch`, and PeerChannel tests for missing/mismatched cluster id and non-service auth.

### Testing
- Added unit tests: `api_balancing/internal/federation/server_auth_test.go` covering service-auth requirement, tenant mismatch rejection, and PeerChannel cluster-id assertions; these tests are committed as regression coverage for the changes.
- Attempted full test runs but environment limitations prevented completion: `make test` failed in CI container due to missing `protoc-gen-go` in PATH (protoc/codegen failure). `go test` of the repo packages also timed out / failed in this environment due to module/proto generation dependencies and long dependency resolution; targeted attempts to run `go test ./api_balancing/internal/federation` from repo root hit dependency/build timeouts in the sandbox.
- Local package-level checks executed during development validated compilation and linter hooks ran as part of pre-commit; however, automated test execution was blocked by tooling gaps in the sandbox (see `protoc-gen-go` requirement).  

If you want, I can: (1) run the new federation tests in a proper dev environment where `protoc-gen-go` and repo modules are available, (2) extend the same hardening to the remaining federation endpoints (`CreateRemoteClip`, `CreateRemoteDVR`, `ListTenantArtifacts`, `MigrateArtifactMetadata`) in a follow-up, or (3) adjust the auth policy to allow audit/allow metadata policies if any callers require non-service flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d1963fd8c8330a95164ea3919be6d)