### PR TITLE
Align EmptyState shared prop contract and add regression coverage

### DIFF
--- a/website_application/src/lib/components/EmptyState.svelte
+++ b/website_application/src/lib/components/EmptyState.svelte
@@ -2,24 +2,33 @@
   import { cn } from "$lib/utils";
   import { getIconComponent } from "$lib/iconUtils";
   import { Button } from "$lib/components/ui/button";
+  import type { ButtonVariant } from "$lib/components/ui/button";
+  import {
+    resolveEmptyStateIcon,
+    type EmptyStateSize,
+    type EmptyStateVariant,
+  } from "$lib/components/empty-state-contract";
+  import type { IconName } from "$lib/iconUtils";
   import type { Snippet } from "svelte";
 
   interface Props {
-    iconName?: string;
+    icon?: IconName;
+    iconName?: IconName;
     title?: string;
     description?: string;
     actionText?: string;
     onAction?: () => void;
-    size?: "sm" | "md" | "lg";
-    variant?: "default" | "accent" | "subtle";
-    buttonVariant?: "default" | "cta" | "outline" | "ghost" | "secondary" | "destructive";
+    size?: EmptyStateSize;
+    variant?: EmptyStateVariant;
+    buttonVariant?: ButtonVariant;
     class?: string;
     showAction?: boolean;
     children?: Snippet;
   }
 
   let {
-    iconName = "FileText",
+    icon,
+    iconName,
     title = "No data found",
     description = "",
     actionText = "",
@@ -32,7 +41,8 @@
     children,
   }: Props = $props();
 
-  const iconComponent = $derived(getIconComponent(iconName));
+  const resolvedIcon = $derived(resolveEmptyStateIcon({ icon, iconName }));
+  const iconComponent = $derived(getIconComponent(resolvedIcon));
 
   const sizeClasses = {
     sm: {

--- a/website_application/src/lib/components/empty-state-contract.test.ts
+++ b/website_application/src/lib/components/empty-state-contract.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, expectTypeOf } from "vitest";
+import {
+  resolveEmptyStateIcon,
+  type EmptyStateContract,
+  type EmptyStateIconProps,
+} from "./empty-state-contract";
+
+describe("resolveEmptyStateIcon", () => {
+  it("keeps the previous iconName contract", () => {
+    expect(resolveEmptyStateIcon({ iconName: "Users" })).toBe("Users");
+  });
+
+  it("supports icon alias for API consistency", () => {
+    expect(resolveEmptyStateIcon({ icon: "Globe" })).toBe("Globe");
+  });
+
+  it("prefers iconName when both props are present", () => {
+    expect(resolveEmptyStateIcon({ icon: "Globe", iconName: "Users" })).toBe("Users");
+  });
+
+  it("falls back to FileText when icon props are missing", () => {
+    expect(resolveEmptyStateIcon({})).toBe("FileText");
+  });
+});
+
+describe("EmptyState contract types", () => {
+  it("keeps icon props constrained to known icon names", () => {
+    expectTypeOf<EmptyStateIconProps>().toMatchTypeOf<{ icon?: string; iconName?: string }>();
+  });
+
+  it("keeps buttonVariant aligned with Button variant API", () => {
+    expectTypeOf<EmptyStateContract>().toMatchTypeOf<{ buttonVariant?: string }>();
+  });
+});

--- a/website_application/src/lib/components/empty-state-contract.ts
+++ b/website_application/src/lib/components/empty-state-contract.ts
@@ -1,0 +1,20 @@
+import type { IconName } from "$lib/iconUtils";
+import type { ButtonVariant } from "$lib/components/ui/button";
+
+export type EmptyStateSize = "sm" | "md" | "lg";
+export type EmptyStateVariant = "default" | "accent" | "subtle";
+
+export interface EmptyStateIconProps {
+  icon?: IconName;
+  iconName?: IconName;
+}
+
+export interface EmptyStateContract extends EmptyStateIconProps {
+  buttonVariant?: ButtonVariant;
+  size?: EmptyStateSize;
+  variant?: EmptyStateVariant;
+}
+
+export function resolveEmptyStateIcon({ icon, iconName }: EmptyStateIconProps): IconName {
+  return iconName ?? icon ?? "FileText";
+}


### PR DESCRIPTION
### Motivation
- Centralize and stabilize the `EmptyState` component API to prevent drift between local prop unions and shared UI primitives by providing a single contract and a small resolver for icon props (preserve backwards compatibility).【F:website_application/src/lib/components/EmptyState.svelte†L5-L45】【F:website_application/src/lib/components/empty-state-contract.ts†L1-L20】

### Description
- Introduced a shared contract module `empty-state-contract.ts` that exports `EmptyStateContract` types, `EmptyStateSize`/`EmptyStateVariant` unions and `resolveEmptyStateIcon` to centralize icon/button variant typing and logic; see `website_application/src/lib/components/empty-state-contract.ts` (lines 1-20).【F:website_application/src/lib/components/empty-state-contract.ts†L1-L20】
- Updated `EmptyState.svelte` to accept a non-breaking `icon` alias while keeping `iconName` (with `iconName` taking precedence), and to consume the shared contract types for `size`, `variant`, and `buttonVariant`; see `website_application/src/lib/components/EmptyState.svelte` (imports and prop block at lines 5-45).【F:website_application/src/lib/components/EmptyState.svelte†L5-L45】
- Added `empty-state-contract.test.ts` containing runtime tests for icon resolution and type-level assertions to prevent future contract drift; see `website_application/src/lib/components/empty-state-contract.test.ts` (lines 1-34).【F:website_application/src/lib/components/empty-state-contract.test.ts†L1-L34】

### Testing
- Ran `pnpm exec svelte-kit sync` successfully to populate Svelte kit artifacts before type-aware tests. (success)
- Ran the focused unit tests with `pnpm test -- empty-state-contract.test.ts` and the suite passed (`6 tests`, all green). (success)
- Ran formatting and lint checks with `pnpm exec prettier --check ...` and `pnpm exec eslint ...` on the modified files and they completed with no formatting issues; commit hooks also ran local frontend linters. (success)
- Ran the full `pnpm check` which fails on pre-existing, unrelated repository-wide issues (missing `$houdini` generated types and other type errors); this failure is unrelated to the change in this PR and was observed as part of verification. (known-failure)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f179662648330bc8e16c930583cdf)